### PR TITLE
Update package dependencies to resolve vulnerability issues (DSI-6985) 

### DIFF
--- a/lib/handlers/invite/publicInvitationNotifyRelyingPartyV1.js
+++ b/lib/handlers/invite/publicInvitationNotifyRelyingPartyV1.js
@@ -1,4 +1,4 @@
-const rp = require('request-promise');
+const { fetchApi } = require('login.dfe.async-retry');
 const jwt = require('jsonwebtoken');
 const ApplicationsClient = require('./../../infrastructure/applications');
 const { v4: uuid } = require('uuid');
@@ -36,9 +36,8 @@ const process = async (config, logger, data) => {
   const token = await getToken(config, clientId, correlationId);
 
   try {
-    await rp({
+    await fetchApi(callback, {
       method: 'POST',
-      uri: callback,
       headers: {
         authorization: `bearer ${token}`,
       },
@@ -46,8 +45,7 @@ const process = async (config, logger, data) => {
         sub: userId,
         sourceId,
         state,
-      },
-      json: true,
+      }
     });
   } catch (e) {
     logger.error(`Error notifying rp - ${e.message}. (userId: ${userId}, sourceId: ${sourceId}, callback: ${callback})`, { correlationId });

--- a/lib/infrastructure/ApiClient.js
+++ b/lib/infrastructure/ApiClient.js
@@ -1,5 +1,5 @@
 const jwtStrategy = require('login.dfe.jwt-strategies');
-const rp = require('request-promise');
+const { fetchApi } = require('login.dfe.async-retry');
 
 class ApiClient {
   constructor(opts, correlationId) {
@@ -22,15 +22,13 @@ class ApiClient {
       : `${this.opts.url}${resource}`;
 
     try {
-      return await rp({
+      return await fetchApi(uri,{
         method,
-        uri,
         headers: {
           'x-correlation-id': this.correlationId,
           'authorization': `bearer ${this.token}`,
         },
-        body,
-        json: true,
+        body
       })
     } catch (e) {
       const status = e.statusCode || 500;

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,8 +11,8 @@
       "dependencies": {
         "jsonwebtoken": "^8.5.1",
         "lodash": "^4.17.21",
-        "login.dfe.jwt-strategies": "git+https://github.com/DFE-Digital/login.dfe.jwt-strategies.git#v4.0.0",
-        "login.dfe.kue": "git+https://github.com/DFE-Digital/login.dfe.kue.git#v0.11.6",
+        "login.dfe.jwt-strategies": "github:DFE-Digital/login.dfe.jwt-strategies#v4.1.0",
+        "login.dfe.kue": "github:DFE-Digital/login.dfe.kue#v0.12.0",
         "request": "^2.88.2",
         "request-promise": "^4.2.6",
         "uuid": "^8.3.2"

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,137 +26,78 @@
         "jest-cli": "^29.6.3"
       }
     },
-    "node_modules/@aashutoshrathi/word-wrap": {
-      "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/@aashutoshrathi/word-wrap/-/word-wrap-1.2.6.tgz",
-      "integrity": "sha512-1Yjs2SvM8TflER/OD3cOjhWWOZb58A2t7wpE2S9XfBYTiIl+XFhQG2bjy4Pu1I+EAlCNUzRDYDdFwFYUKvXcIA==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/@ampproject/remapping": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.2.1.tgz",
-      "integrity": "sha512-lFMjJTrFL3j7L9yBxwYfCq2k6qqwHyzuUl/XBnif78PWTJYyL/dfowQHWE3sp6U6ZzqWiiIZnpTMO96zhkjwtg==",
+      "version": "2.3.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@ampproject/remapping/-/remapping-2.3.0.tgz",
+      "integrity": "sha1-7UQbb6YAByUgzhi0PSyMyMrsx/Q=",
       "dev": true,
       "dependencies": {
-        "@jridgewell/gen-mapping": "^0.3.0",
-        "@jridgewell/trace-mapping": "^0.3.9"
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
       },
       "engines": {
         "node": ">=6.0.0"
       }
     },
+    "node_modules/@azure/msal-common": {
+      "version": "14.10.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@azure/msal-common/-/msal-common-14.10.0.tgz",
+      "integrity": "sha1-IVRJcmcXtT1UmVPbd1YsrWy4Qhw=",
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/@azure/msal-node": {
+      "version": "2.8.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@azure/msal-node/-/msal-node-2.8.1.tgz",
+      "integrity": "sha1-re0o037qLnJ4yb1E8gFmRzkPI5w=",
+      "dependencies": {
+        "@azure/msal-common": "14.10.0",
+        "jsonwebtoken": "^9.0.0",
+        "uuid": "^8.3.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/@babel/code-frame": {
-      "version": "7.22.13",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.22.13.tgz",
-      "integrity": "sha512-XktuhWlJ5g+3TJXc5upd9Ks1HutSArik6jf2eAjYFyIOf4ej3RN+184cZbzDvbPnuTJIUhPKKJE3cIsYTiAT3w==",
+      "version": "7.24.6",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@babel/code-frame/-/code-frame-7.24.6.tgz",
+      "integrity": "sha1-q4jaGTRERcPYiJryIWYG0zKfPvI=",
       "dev": true,
       "dependencies": {
-        "@babel/highlight": "^7.22.13",
-        "chalk": "^2.4.2"
+        "@babel/highlight": "^7.24.6",
+        "picocolors": "^1.0.0"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@babel/code-frame/node_modules/ansi-styles": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-      "dev": true,
-      "dependencies": {
-        "color-convert": "^1.9.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/@babel/code-frame/node_modules/chalk": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-      "dev": true,
-      "dependencies": {
-        "ansi-styles": "^3.2.1",
-        "escape-string-regexp": "^1.0.5",
-        "supports-color": "^5.3.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/@babel/code-frame/node_modules/color-convert": {
-      "version": "1.9.3",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-      "dev": true,
-      "dependencies": {
-        "color-name": "1.1.3"
-      }
-    },
-    "node_modules/@babel/code-frame/node_modules/color-name": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
-      "dev": true
-    },
-    "node_modules/@babel/code-frame/node_modules/escape-string-regexp": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.8.0"
-      }
-    },
-    "node_modules/@babel/code-frame/node_modules/has-flag": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
-      "dev": true,
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/@babel/code-frame/node_modules/supports-color": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-      "dev": true,
-      "dependencies": {
-        "has-flag": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/@babel/compat-data": {
-      "version": "7.23.2",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.23.2.tgz",
-      "integrity": "sha512-0S9TQMmDHlqAZ2ITT95irXKfxN9bncq8ZCoJhun3nHL/lLUxd2NKBJYoNGWH7S0hz6fRQwWlAWn/ILM0C70KZQ==",
+      "version": "7.24.6",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@babel/compat-data/-/compat-data-7.24.6.tgz",
+      "integrity": "sha1-s2ACF2iMq7JuJfjkZwGeZtcbeuI=",
       "dev": true,
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/core": {
-      "version": "7.23.2",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.23.2.tgz",
-      "integrity": "sha512-n7s51eWdaWZ3vGT2tD4T7J6eJs3QoBXydv7vkUM06Bf1cbVD2Kc2UrkzhiQwobfV7NwOnQXYL7UBJ5VPU+RGoQ==",
+      "version": "7.24.6",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@babel/core/-/core-7.24.6.tgz",
+      "integrity": "sha1-hlDg5LA1ievohsTkpgOY2wp+x4c=",
       "dev": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
-        "@babel/code-frame": "^7.22.13",
-        "@babel/generator": "^7.23.0",
-        "@babel/helper-compilation-targets": "^7.22.15",
-        "@babel/helper-module-transforms": "^7.23.0",
-        "@babel/helpers": "^7.23.2",
-        "@babel/parser": "^7.23.0",
-        "@babel/template": "^7.22.15",
-        "@babel/traverse": "^7.23.2",
-        "@babel/types": "^7.23.0",
+        "@babel/code-frame": "^7.24.6",
+        "@babel/generator": "^7.24.6",
+        "@babel/helper-compilation-targets": "^7.24.6",
+        "@babel/helper-module-transforms": "^7.24.6",
+        "@babel/helpers": "^7.24.6",
+        "@babel/parser": "^7.24.6",
+        "@babel/template": "^7.24.6",
+        "@babel/traverse": "^7.24.6",
+        "@babel/types": "^7.24.6",
         "convert-source-map": "^2.0.0",
         "debug": "^4.1.0",
         "gensync": "^1.0.0-beta.2",
@@ -173,8 +114,8 @@
     },
     "node_modules/@babel/core/node_modules/debug": {
       "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha1-Exn2V5NX8jONMzfSzdSRS7XcyGU=",
       "dev": true,
       "dependencies": {
         "ms": "2.1.2"
@@ -190,19 +131,19 @@
     },
     "node_modules/@babel/core/node_modules/ms": {
       "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha1-0J0fNXtEP0kzgqjrPM0YOHKuYAk=",
       "dev": true
     },
     "node_modules/@babel/generator": {
-      "version": "7.23.0",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.23.0.tgz",
-      "integrity": "sha512-lN85QRR+5IbYrMWM6Y4pE/noaQtg4pNiqeNGX60eqOfo6gtEj6uw/JagelB8vVztSd7R6M5n1+PQkDbHbBRU4g==",
+      "version": "7.24.6",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@babel/generator/-/generator-7.24.6.tgz",
+      "integrity": "sha1-36yCoihYKp0wyVn+UK0olR1HN6c=",
       "dev": true,
       "dependencies": {
-        "@babel/types": "^7.23.0",
-        "@jridgewell/gen-mapping": "^0.3.2",
-        "@jridgewell/trace-mapping": "^0.3.17",
+        "@babel/types": "^7.24.6",
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.25",
         "jsesc": "^2.5.1"
       },
       "engines": {
@@ -210,14 +151,14 @@
       }
     },
     "node_modules/@babel/helper-compilation-targets": {
-      "version": "7.22.15",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.22.15.tgz",
-      "integrity": "sha512-y6EEzULok0Qvz8yyLkCvVX+02ic+By2UdOhylwUOvOn9dvYc9mKICJuuU1n1XBI02YWsNsnrY1kc6DVbjcXbtw==",
+      "version": "7.24.6",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@babel/helper-compilation-targets/-/helper-compilation-targets-7.24.6.tgz",
+      "integrity": "sha1-SlHWgfdoAEPTjiEnFeKnsa0py1E=",
       "dev": true,
       "dependencies": {
-        "@babel/compat-data": "^7.22.9",
-        "@babel/helper-validator-option": "^7.22.15",
-        "browserslist": "^4.21.9",
+        "@babel/compat-data": "^7.24.6",
+        "@babel/helper-validator-option": "^7.24.6",
+        "browserslist": "^4.22.2",
         "lru-cache": "^5.1.1",
         "semver": "^6.3.1"
       },
@@ -226,62 +167,62 @@
       }
     },
     "node_modules/@babel/helper-environment-visitor": {
-      "version": "7.22.20",
-      "resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.22.20.tgz",
-      "integrity": "sha512-zfedSIzFhat/gFhWfHtgWvlec0nqB9YEIVrpuwjruLlXfUSnA8cJB0miHKwqDnQ7d32aKo2xt88/xZptwxbfhA==",
+      "version": "7.24.6",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@babel/helper-environment-visitor/-/helper-environment-visitor-7.24.6.tgz",
+      "integrity": "sha1-rHrVUXghZBVQ9mmN1UaPjO94Yg0=",
       "dev": true,
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-function-name": {
-      "version": "7.23.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.23.0.tgz",
-      "integrity": "sha512-OErEqsrxjZTJciZ4Oo+eoZqeW9UIiOcuYKRJA4ZAgV9myA+pOXhhmpfNCKjEH/auVfEYVFJ6y1Tc4r0eIApqiw==",
+      "version": "7.24.6",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@babel/helper-function-name/-/helper-function-name-7.24.6.tgz",
+      "integrity": "sha1-zr3QYzhv25XVEdhLEX5R/Gj+wMg=",
       "dev": true,
       "dependencies": {
-        "@babel/template": "^7.22.15",
-        "@babel/types": "^7.23.0"
+        "@babel/template": "^7.24.6",
+        "@babel/types": "^7.24.6"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-hoist-variables": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.22.5.tgz",
-      "integrity": "sha512-wGjk9QZVzvknA6yKIUURb8zY3grXCcOZt+/7Wcy8O2uctxhplmUPkOdlgoNhmdVee2c92JXbf1xpMtVNbfoxRw==",
+      "version": "7.24.6",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@babel/helper-hoist-variables/-/helper-hoist-variables-7.24.6.tgz",
+      "integrity": "sha1-in7OjCZ1aCa2/83Q489l3ida9/k=",
       "dev": true,
       "dependencies": {
-        "@babel/types": "^7.22.5"
+        "@babel/types": "^7.24.6"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-module-imports": {
-      "version": "7.22.15",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.22.15.tgz",
-      "integrity": "sha512-0pYVBnDKZO2fnSPCrgM/6WMc7eS20Fbok+0r88fp+YtWVLZrp4CkafFGIp+W0VKw4a22sgebPT99y+FDNMdP4w==",
+      "version": "7.24.6",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@babel/helper-module-imports/-/helper-module-imports-7.24.6.tgz",
+      "integrity": "sha1-ZeVP/O7WomjcTOEfBDO4LP/1eFI=",
       "dev": true,
       "dependencies": {
-        "@babel/types": "^7.22.15"
+        "@babel/types": "^7.24.6"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-module-transforms": {
-      "version": "7.23.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.23.0.tgz",
-      "integrity": "sha512-WhDWw1tdrlT0gMgUJSlX0IQvoO1eN279zrAUbVB+KpV2c3Tylz8+GnKOLllCS6Z/iZQEyVYxhZVUdPTqs2YYPw==",
+      "version": "7.24.6",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@babel/helper-module-transforms/-/helper-module-transforms-7.24.6.tgz",
+      "integrity": "sha1-IjRu2d9EzoTe6FDXQzxbc/qx/k4=",
       "dev": true,
       "dependencies": {
-        "@babel/helper-environment-visitor": "^7.22.20",
-        "@babel/helper-module-imports": "^7.22.15",
-        "@babel/helper-simple-access": "^7.22.5",
-        "@babel/helper-split-export-declaration": "^7.22.6",
-        "@babel/helper-validator-identifier": "^7.22.20"
+        "@babel/helper-environment-visitor": "^7.24.6",
+        "@babel/helper-module-imports": "^7.24.6",
+        "@babel/helper-simple-access": "^7.24.6",
+        "@babel/helper-split-export-declaration": "^7.24.6",
+        "@babel/helper-validator-identifier": "^7.24.6"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -291,86 +232,86 @@
       }
     },
     "node_modules/@babel/helper-plugin-utils": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.22.5.tgz",
-      "integrity": "sha512-uLls06UVKgFG9QD4OeFYLEGteMIAa5kpTPcFL28yuCIIzsf6ZyKZMllKVOCZFhiZ5ptnwX4mtKdWCBE/uT4amg==",
+      "version": "7.24.6",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@babel/helper-plugin-utils/-/helper-plugin-utils-7.24.6.tgz",
+      "integrity": "sha1-+gKjJBChWm6PgYW8v2CPEFKNKiQ=",
       "dev": true,
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-simple-access": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.22.5.tgz",
-      "integrity": "sha512-n0H99E/K+Bika3++WNL17POvo4rKWZ7lZEp1Q+fStVbUi8nxPQEBOlTmCOxW/0JsS56SKKQ+ojAe2pHKJHN35w==",
+      "version": "7.24.6",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@babel/helper-simple-access/-/helper-simple-access-7.24.6.tgz",
+      "integrity": "sha1-HW4E1Gi7pPyWO0kG9trGKGz+3/E=",
       "dev": true,
       "dependencies": {
-        "@babel/types": "^7.22.5"
+        "@babel/types": "^7.24.6"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-split-export-declaration": {
-      "version": "7.22.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.22.6.tgz",
-      "integrity": "sha512-AsUnxuLhRYsisFiaJwvp1QF+I3KjD5FOxut14q/GzovUe6orHLesW2C7d754kRm53h5gqrz6sFl6sxc4BVtE/g==",
+      "version": "7.24.6",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.24.6.tgz",
+      "integrity": "sha1-6DAGj3uohhxTt0IcKE2jCuZW16M=",
       "dev": true,
       "dependencies": {
-        "@babel/types": "^7.22.5"
+        "@babel/types": "^7.24.6"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-string-parser": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.22.5.tgz",
-      "integrity": "sha512-mM4COjgZox8U+JcXQwPijIZLElkgEpO5rsERVDJTc2qfCDfERyob6k5WegS14SX18IIjv+XD+GrqNumY5JRCDw==",
+      "version": "7.24.6",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@babel/helper-string-parser/-/helper-string-parser-7.24.6.tgz",
+      "integrity": "sha1-KFg8KLFfKjM5z6+v6q1C+aDoKN8=",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.22.20",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.20.tgz",
-      "integrity": "sha512-Y4OZ+ytlatR8AI+8KZfKuL5urKp7qey08ha31L8b3BwewJAoJamTzyvxPR/5D+KkdJCGPq/+8TukHBlY10FX9A==",
+      "version": "7.24.6",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@babel/helper-validator-identifier/-/helper-validator-identifier-7.24.6.tgz",
+      "integrity": "sha1-CLtmErEb3sePP+7T2xltpoJFSl4=",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-validator-option": {
-      "version": "7.22.15",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.22.15.tgz",
-      "integrity": "sha512-bMn7RmyFjY/mdECUbgn9eoSY4vqvacUnS9i9vGAGttgFWesO6B4CYWA7XlpbWgBt71iv/hfbPlynohStqnu5hA==",
+      "version": "7.24.6",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@babel/helper-validator-option/-/helper-validator-option-7.24.6.tgz",
+      "integrity": "sha1-WdjoHEC32RCat+dEVzk0Qhd/Rgo=",
       "dev": true,
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.23.2",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.23.2.tgz",
-      "integrity": "sha512-lzchcp8SjTSVe/fPmLwtWVBFC7+Tbn8LGHDVfDp9JGxpAY5opSaEFgt8UQvrnECWOTdji2mOWMz1rOhkHscmGQ==",
+      "version": "7.24.6",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@babel/helpers/-/helpers-7.24.6.tgz",
+      "integrity": "sha1-zRJCRSmeSUvU4A7doOTqNUXCwXY=",
       "dev": true,
       "dependencies": {
-        "@babel/template": "^7.22.15",
-        "@babel/traverse": "^7.23.2",
-        "@babel/types": "^7.23.0"
+        "@babel/template": "^7.24.6",
+        "@babel/types": "^7.24.6"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/highlight": {
-      "version": "7.22.20",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.22.20.tgz",
-      "integrity": "sha512-dkdMCN3py0+ksCgYmGG8jKeGA/8Tk+gJwSYYlFGxG5lmhfKNoAy004YpLxpS1W2J8m/EK2Ew+yOs9pVRwO89mg==",
+      "version": "7.24.6",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@babel/highlight/-/highlight-7.24.6.tgz",
+      "integrity": "sha1-bWEMHr0sbgYcreAVO/abBZC3s98=",
       "dev": true,
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.22.20",
+        "@babel/helper-validator-identifier": "^7.24.6",
         "chalk": "^2.4.2",
-        "js-tokens": "^4.0.0"
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.0.0"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -378,8 +319,8 @@
     },
     "node_modules/@babel/highlight/node_modules/ansi-styles": {
       "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha1-QfuyAkPlCxK+DwS43tvwdSDOhB0=",
       "dev": true,
       "dependencies": {
         "color-convert": "^1.9.0"
@@ -390,8 +331,8 @@
     },
     "node_modules/@babel/highlight/node_modules/chalk": {
       "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/chalk/-/chalk-2.4.2.tgz",
+      "integrity": "sha1-zUJUFnelQzPPVBpJEIwUMrRMlCQ=",
       "dev": true,
       "dependencies": {
         "ansi-styles": "^3.2.1",
@@ -404,8 +345,8 @@
     },
     "node_modules/@babel/highlight/node_modules/color-convert": {
       "version": "1.9.3",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha1-u3GFBpDh8TZWfeYp0tVHHe2kweg=",
       "dev": true,
       "dependencies": {
         "color-name": "1.1.3"
@@ -413,14 +354,14 @@
     },
     "node_modules/@babel/highlight/node_modules/color-name": {
       "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
       "dev": true
     },
     "node_modules/@babel/highlight/node_modules/escape-string-regexp": {
       "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
       "dev": true,
       "engines": {
         "node": ">=0.8.0"
@@ -428,8 +369,8 @@
     },
     "node_modules/@babel/highlight/node_modules/has-flag": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
       "dev": true,
       "engines": {
         "node": ">=4"
@@ -437,8 +378,8 @@
     },
     "node_modules/@babel/highlight/node_modules/supports-color": {
       "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha1-4uaaRKyHcveKHsCzW2id9lMO/I8=",
       "dev": true,
       "dependencies": {
         "has-flag": "^3.0.0"
@@ -448,9 +389,9 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.23.0",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.23.0.tgz",
-      "integrity": "sha512-vvPKKdMemU85V9WE/l5wZEmImpCtLqbnTvqDS2U1fJ96KrxoW7KrXhNsNCblQlg8Ck4b85yxdTyelsMUgFUXiw==",
+      "version": "7.24.6",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@babel/parser/-/parser-7.24.6.tgz",
+      "integrity": "sha1-XgMPRAw8bHjRlVKMO2iLEBo2Uyg=",
       "bin": {
         "parser": "bin/babel-parser.js"
       },
@@ -460,8 +401,8 @@
     },
     "node_modules/@babel/plugin-syntax-async-generators": {
       "version": "7.8.4",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.8.4.tgz",
-      "integrity": "sha512-tycmZxkGfZaxhMRbXlPXuVFpdWlXpir2W4AMhSJgRKzk/eDlIXOhb2LHWoLpDF7TEHylV5zNhykX6KAgHJmTNw==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.8.4.tgz",
+      "integrity": "sha1-qYP7Gusuw/btBCohD2QOkOeG/g0=",
       "dev": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.8.0"
@@ -472,8 +413,8 @@
     },
     "node_modules/@babel/plugin-syntax-bigint": {
       "version": "7.8.3",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-bigint/-/plugin-syntax-bigint-7.8.3.tgz",
-      "integrity": "sha512-wnTnFlG+YxQm3vDxpGE57Pj0srRU4sHE/mDkt1qv2YJJSeUAec2ma4WLUnUPeKjyrfntVwe/N6dCXpU+zL3Npg==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@babel/plugin-syntax-bigint/-/plugin-syntax-bigint-7.8.3.tgz",
+      "integrity": "sha1-TJpvZp9dDN8bkKFnHpoUa+UwDOo=",
       "dev": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.8.0"
@@ -484,8 +425,8 @@
     },
     "node_modules/@babel/plugin-syntax-class-properties": {
       "version": "7.12.13",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-properties/-/plugin-syntax-class-properties-7.12.13.tgz",
-      "integrity": "sha512-fm4idjKla0YahUNgFNLCB0qySdsoPiZP3iQE3rky0mBUtMZ23yDJ9SJdg6dXTSDnulOVqiF3Hgr9nbXvXTQZYA==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@babel/plugin-syntax-class-properties/-/plugin-syntax-class-properties-7.12.13.tgz",
+      "integrity": "sha1-tcmHJ0xKOoK4lxR5aTGmtTVErhA=",
       "dev": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.12.13"
@@ -496,8 +437,8 @@
     },
     "node_modules/@babel/plugin-syntax-import-meta": {
       "version": "7.10.4",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-meta/-/plugin-syntax-import-meta-7.10.4.tgz",
-      "integrity": "sha512-Yqfm+XDx0+Prh3VSeEQCPU81yC+JWZ2pDPFSS4ZdpfZhp4MkFMaDC1UqseovEKwSUpnIL7+vK+Clp7bfh0iD7g==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@babel/plugin-syntax-import-meta/-/plugin-syntax-import-meta-7.10.4.tgz",
+      "integrity": "sha1-7mATSMNw+jNNIge+FYd3SWUh/VE=",
       "dev": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.10.4"
@@ -508,8 +449,8 @@
     },
     "node_modules/@babel/plugin-syntax-json-strings": {
       "version": "7.8.3",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-json-strings/-/plugin-syntax-json-strings-7.8.3.tgz",
-      "integrity": "sha512-lY6kdGpWHvjoe2vk4WrAapEuBR69EMxZl+RoGRhrFGNYVK8mOPAW8VfbT/ZgrFbXlDNiiaxQnAtgVCZ6jv30EA==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@babel/plugin-syntax-json-strings/-/plugin-syntax-json-strings-7.8.3.tgz",
+      "integrity": "sha1-AcohtmjNghjJ5kDLbdiMVBKyyWo=",
       "dev": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.8.0"
@@ -519,12 +460,12 @@
       }
     },
     "node_modules/@babel/plugin-syntax-jsx": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.22.5.tgz",
-      "integrity": "sha512-gvyP4hZrgrs/wWMaocvxZ44Hw0b3W8Pe+cMxc8V1ULQ07oh8VNbIRaoD1LRZVTvD+0nieDKjfgKg89sD7rrKrg==",
+      "version": "7.24.6",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.24.6.tgz",
+      "integrity": "sha1-vMopZBUEN/iPZeNnnj1odiKHucg=",
       "dev": true,
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.22.5"
+        "@babel/helper-plugin-utils": "^7.24.6"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -535,8 +476,8 @@
     },
     "node_modules/@babel/plugin-syntax-logical-assignment-operators": {
       "version": "7.10.4",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-logical-assignment-operators/-/plugin-syntax-logical-assignment-operators-7.10.4.tgz",
-      "integrity": "sha512-d8waShlpFDinQ5MtvGU9xDAOzKH47+FFoney2baFIoMr952hKOLp1HR7VszoZvOsV/4+RRszNY7D17ba0te0ig==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@babel/plugin-syntax-logical-assignment-operators/-/plugin-syntax-logical-assignment-operators-7.10.4.tgz",
+      "integrity": "sha1-ypHvRjA1MESLkGZSusLp/plB9pk=",
       "dev": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.10.4"
@@ -547,8 +488,8 @@
     },
     "node_modules/@babel/plugin-syntax-nullish-coalescing-operator": {
       "version": "7.8.3",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-nullish-coalescing-operator/-/plugin-syntax-nullish-coalescing-operator-7.8.3.tgz",
-      "integrity": "sha512-aSff4zPII1u2QD7y+F8oDsz19ew4IGEJg9SVW+bqwpwtfFleiQDMdzA/R+UlWDzfnHFCxxleFT0PMIrR36XLNQ==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@babel/plugin-syntax-nullish-coalescing-operator/-/plugin-syntax-nullish-coalescing-operator-7.8.3.tgz",
+      "integrity": "sha1-Fn7XA2iIYIH3S1w2xlqIwDtm0ak=",
       "dev": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.8.0"
@@ -559,8 +500,8 @@
     },
     "node_modules/@babel/plugin-syntax-numeric-separator": {
       "version": "7.10.4",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-numeric-separator/-/plugin-syntax-numeric-separator-7.10.4.tgz",
-      "integrity": "sha512-9H6YdfkcK/uOnY/K7/aA2xpzaAgkQn37yzWUMRK7OaPOqOpGS1+n0H5hxT9AUw9EsSjPW8SVyMJwYRtWs3X3ug==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@babel/plugin-syntax-numeric-separator/-/plugin-syntax-numeric-separator-7.10.4.tgz",
+      "integrity": "sha1-ubBws+M1cM2f0Hun+pHA3Te5r5c=",
       "dev": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.10.4"
@@ -571,8 +512,8 @@
     },
     "node_modules/@babel/plugin-syntax-object-rest-spread": {
       "version": "7.8.3",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.8.3.tgz",
-      "integrity": "sha512-XoqMijGZb9y3y2XskN+P1wUGiVwWZ5JmoDRwx5+3GmEplNyVM2s2Dg8ILFQm8rWM48orGy5YpI5Bl8U1y7ydlA==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.8.3.tgz",
+      "integrity": "sha1-YOIl7cvZimQDMqLnLdPmbxr1WHE=",
       "dev": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.8.0"
@@ -583,8 +524,8 @@
     },
     "node_modules/@babel/plugin-syntax-optional-catch-binding": {
       "version": "7.8.3",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.8.3.tgz",
-      "integrity": "sha512-6VPD0Pc1lpTqw0aKoeRTMiB+kWhAoT24PA+ksWSBrFtl5SIRVpZlwN3NNPQjehA2E/91FV3RjLWoVTglWcSV3Q==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.8.3.tgz",
+      "integrity": "sha1-YRGiZbz7Ag6579D9/X0mQCue1sE=",
       "dev": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.8.0"
@@ -595,8 +536,8 @@
     },
     "node_modules/@babel/plugin-syntax-optional-chaining": {
       "version": "7.8.3",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-chaining/-/plugin-syntax-optional-chaining-7.8.3.tgz",
-      "integrity": "sha512-KoK9ErH1MBlCPxV0VANkXW2/dw4vlbGDrFgz8bmUsBGYkFRcbRwMh6cIJubdPrkxRwuGdtCk0v/wPTKbQgBjkg==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@babel/plugin-syntax-optional-chaining/-/plugin-syntax-optional-chaining-7.8.3.tgz",
+      "integrity": "sha1-T2nCq5UWfgGAzVM2YT+MV4j31Io=",
       "dev": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.8.0"
@@ -607,8 +548,8 @@
     },
     "node_modules/@babel/plugin-syntax-top-level-await": {
       "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-top-level-await/-/plugin-syntax-top-level-await-7.14.5.tgz",
-      "integrity": "sha512-hx++upLv5U1rgYfwe1xBQUhRmU41NEvpUvrp8jkrSCdvGSnM5/qdRMtylJ6PG5OFkBaHkbTAKTnd3/YyESRHFw==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@babel/plugin-syntax-top-level-await/-/plugin-syntax-top-level-await-7.14.5.tgz",
+      "integrity": "sha1-wc/a3DWmRiQAAfBhOCR7dBw02Uw=",
       "dev": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.14.5"
@@ -621,12 +562,12 @@
       }
     },
     "node_modules/@babel/plugin-syntax-typescript": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.22.5.tgz",
-      "integrity": "sha512-1mS2o03i7t1c6VzH6fdQ3OA8tcEIxwG18zIPRp+UY1Ihv6W+XZzBCVxExF9upussPXJ0xE9XRHwMoNs1ep/nRQ==",
+      "version": "7.24.6",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.24.6.tgz",
+      "integrity": "sha1-dp2vKYLWAwi8g9iTbq7LdYJGPIc=",
       "dev": true,
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.22.5"
+        "@babel/helper-plugin-utils": "^7.24.6"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -636,34 +577,34 @@
       }
     },
     "node_modules/@babel/template": {
-      "version": "7.22.15",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.22.15.tgz",
-      "integrity": "sha512-QPErUVm4uyJa60rkI73qneDacvdvzxshT3kksGqlGWYdOTIUOwJ7RDUL8sGqslY1uXWSL6xMFKEXDS3ox2uF0w==",
+      "version": "7.24.6",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@babel/template/-/template-7.24.6.tgz",
+      "integrity": "sha1-BIw0eyeHpgcrJMcjZkyNArZ6RPk=",
       "dev": true,
       "dependencies": {
-        "@babel/code-frame": "^7.22.13",
-        "@babel/parser": "^7.22.15",
-        "@babel/types": "^7.22.15"
+        "@babel/code-frame": "^7.24.6",
+        "@babel/parser": "^7.24.6",
+        "@babel/types": "^7.24.6"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.23.2",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.23.2.tgz",
-      "integrity": "sha512-azpe59SQ48qG6nu2CzcMLbxUudtN+dOM9kDbUqGq3HXUJRlo7i8fvPoxQUzYgLZ4cMVmuZgm8vvBpNeRhd6XSw==",
+      "version": "7.24.6",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@babel/traverse/-/traverse-7.24.6.tgz",
+      "integrity": "sha1-CUHsUM3q6srQkR62euInpPhCTtw=",
       "dev": true,
       "dependencies": {
-        "@babel/code-frame": "^7.22.13",
-        "@babel/generator": "^7.23.0",
-        "@babel/helper-environment-visitor": "^7.22.20",
-        "@babel/helper-function-name": "^7.23.0",
-        "@babel/helper-hoist-variables": "^7.22.5",
-        "@babel/helper-split-export-declaration": "^7.22.6",
-        "@babel/parser": "^7.23.0",
-        "@babel/types": "^7.23.0",
-        "debug": "^4.1.0",
+        "@babel/code-frame": "^7.24.6",
+        "@babel/generator": "^7.24.6",
+        "@babel/helper-environment-visitor": "^7.24.6",
+        "@babel/helper-function-name": "^7.24.6",
+        "@babel/helper-hoist-variables": "^7.24.6",
+        "@babel/helper-split-export-declaration": "^7.24.6",
+        "@babel/parser": "^7.24.6",
+        "@babel/types": "^7.24.6",
+        "debug": "^4.3.1",
         "globals": "^11.1.0"
       },
       "engines": {
@@ -672,8 +613,8 @@
     },
     "node_modules/@babel/traverse/node_modules/debug": {
       "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha1-Exn2V5NX8jONMzfSzdSRS7XcyGU=",
       "dev": true,
       "dependencies": {
         "ms": "2.1.2"
@@ -689,8 +630,8 @@
     },
     "node_modules/@babel/traverse/node_modules/globals": {
       "version": "11.12.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
-      "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/globals/-/globals-11.12.0.tgz",
+      "integrity": "sha1-q4eVM4hooLq9hSV1gBjCp+uVxC4=",
       "dev": true,
       "engines": {
         "node": ">=4"
@@ -698,17 +639,17 @@
     },
     "node_modules/@babel/traverse/node_modules/ms": {
       "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha1-0J0fNXtEP0kzgqjrPM0YOHKuYAk=",
       "dev": true
     },
     "node_modules/@babel/types": {
-      "version": "7.23.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.23.0.tgz",
-      "integrity": "sha512-0oIyUfKoI3mSqMvsxBdclDwxXKXAUA8v/apZbc+iSyARYou1o8ZGDxbUYyLFoW2arqS2jDGqJuZvv1d/io1axg==",
+      "version": "7.24.6",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@babel/types/-/types-7.24.6.tgz",
+      "integrity": "sha1-uk4fWYcMENwvqVonSsT+7COyGRI=",
       "dependencies": {
-        "@babel/helper-string-parser": "^7.22.5",
-        "@babel/helper-validator-identifier": "^7.22.20",
+        "@babel/helper-string-parser": "^7.24.6",
+        "@babel/helper-validator-identifier": "^7.24.6",
         "to-fast-properties": "^2.0.0"
       },
       "engines": {
@@ -717,14 +658,14 @@
     },
     "node_modules/@bcoe/v8-coverage": {
       "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
-      "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
+      "integrity": "sha1-daLotRy3WKdVPWgEpZMteqznXDk=",
       "dev": true
     },
     "node_modules/@eslint-community/eslint-utils": {
       "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.4.0.tgz",
-      "integrity": "sha512-1/sA4dwrzBAyeUoQ6oxahHKmrZvsnLCg4RfxW3ZFGGmQkSNQPFNLV9CUEFQP1x9EYXHTo5p6xdhZM1Ne9p/AfA==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@eslint-community/eslint-utils/-/eslint-utils-4.4.0.tgz",
+      "integrity": "sha1-ojUU6Pua8SadX3eIqlVnmNYca1k=",
       "dev": true,
       "dependencies": {
         "eslint-visitor-keys": "^3.3.0"
@@ -737,18 +678,18 @@
       }
     },
     "node_modules/@eslint-community/regexpp": {
-      "version": "4.9.1",
-      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.9.1.tgz",
-      "integrity": "sha512-Y27x+MBLjXa+0JWDhykM3+JE+il3kHKAEqabfEWq3SDhZjLYb6/BHL/JKFnH3fe207JaXkyDo685Oc2Glt6ifA==",
+      "version": "4.10.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@eslint-community/regexpp/-/regexpp-4.10.0.tgz",
+      "integrity": "sha1-VI9t5VaFfIu3O77nDDXcgqLnTWM=",
       "dev": true,
       "engines": {
         "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
       }
     },
     "node_modules/@eslint/eslintrc": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.1.2.tgz",
-      "integrity": "sha512-+wvgpDsrB1YqAMdEUCcnTlpfVBH7Vqn6A/NT3D8WVXFIaKMlErPIZT3oCIAVCOtarRpMtelZLqJeU3t7WY6X6g==",
+      "version": "2.1.4",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@eslint/eslintrc/-/eslintrc-2.1.4.tgz",
+      "integrity": "sha1-OIomnw8lwbatwxe1osVXFIlMcK0=",
       "dev": true,
       "dependencies": {
         "ajv": "^6.12.4",
@@ -770,8 +711,8 @@
     },
     "node_modules/@eslint/eslintrc/node_modules/debug": {
       "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha1-Exn2V5NX8jONMzfSzdSRS7XcyGU=",
       "dev": true,
       "dependencies": {
         "ms": "2.1.2"
@@ -787,27 +728,27 @@
     },
     "node_modules/@eslint/eslintrc/node_modules/ms": {
       "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha1-0J0fNXtEP0kzgqjrPM0YOHKuYAk=",
       "dev": true
     },
     "node_modules/@eslint/js": {
-      "version": "8.51.0",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.51.0.tgz",
-      "integrity": "sha512-HxjQ8Qn+4SI3/AFv6sOrDB+g6PpUTDwSJiQqOrnneEk8L71161srI9gjzzZvYVbzHiVg/BvcH95+cK/zfIt4pg==",
+      "version": "8.57.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@eslint/js/-/js-8.57.0.tgz",
+      "integrity": "sha1-pUF66EJ4c/HdCLcLNXS0U+Z7X38=",
       "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
     "node_modules/@humanwhocodes/config-array": {
-      "version": "0.11.11",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.11.tgz",
-      "integrity": "sha512-N2brEuAadi0CcdeMXUkhbZB84eskAc8MEX1By6qEchoVywSgXPIjou4rYsl0V3Hj0ZnuGycGCjdNgockbzeWNA==",
+      "version": "0.11.14",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@humanwhocodes/config-array/-/config-array-0.11.14.tgz",
+      "integrity": "sha1-145IGgOfdWbsyWYLTqf+ax/sRCs=",
       "dev": true,
       "dependencies": {
-        "@humanwhocodes/object-schema": "^1.2.1",
-        "debug": "^4.1.1",
+        "@humanwhocodes/object-schema": "^2.0.2",
+        "debug": "^4.3.1",
         "minimatch": "^3.0.5"
       },
       "engines": {
@@ -816,8 +757,8 @@
     },
     "node_modules/@humanwhocodes/config-array/node_modules/debug": {
       "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha1-Exn2V5NX8jONMzfSzdSRS7XcyGU=",
       "dev": true,
       "dependencies": {
         "ms": "2.1.2"
@@ -833,14 +774,14 @@
     },
     "node_modules/@humanwhocodes/config-array/node_modules/ms": {
       "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha1-0J0fNXtEP0kzgqjrPM0YOHKuYAk=",
       "dev": true
     },
     "node_modules/@humanwhocodes/module-importer": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
-      "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+      "integrity": "sha1-r1smkaIrRL6EewyoFkHF+2rQFyw=",
       "dev": true,
       "engines": {
         "node": ">=12.22"
@@ -851,15 +792,15 @@
       }
     },
     "node_modules/@humanwhocodes/object-schema": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz",
-      "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
+      "version": "2.0.3",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@humanwhocodes/object-schema/-/object-schema-2.0.3.tgz",
+      "integrity": "sha1-Siho111taWPkI7z5C3/RvjQ0CdM=",
       "dev": true
     },
     "node_modules/@istanbuljs/load-nyc-config": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",
-      "integrity": "sha512-VjeHSlIzpv/NyD3N0YuHfXOPDIixcA1q2ZV98wsMqcYlPmv2n3Yb2lYP9XMElnaFVXg5A7YLTeLu6V84uQDjmQ==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",
+      "integrity": "sha1-/T2x1Z7PfPEh6AZQu4ZxL5tV7O0=",
       "dev": true,
       "dependencies": {
         "camelcase": "^5.3.1",
@@ -874,8 +815,8 @@
     },
     "node_modules/@istanbuljs/load-nyc-config/node_modules/argparse": {
       "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha1-vNZ5HqWuCXJeF+WtmIE0zUCz2RE=",
       "dev": true,
       "dependencies": {
         "sprintf-js": "~1.0.2"
@@ -883,8 +824,8 @@
     },
     "node_modules/@istanbuljs/load-nyc-config/node_modules/find-up": {
       "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
-      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/find-up/-/find-up-4.1.0.tgz",
+      "integrity": "sha1-l6/n1s3AvFkoWEt8jXsW6KmqXRk=",
       "dev": true,
       "dependencies": {
         "locate-path": "^5.0.0",
@@ -896,8 +837,8 @@
     },
     "node_modules/@istanbuljs/load-nyc-config/node_modules/js-yaml": {
       "version": "3.14.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
-      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/js-yaml/-/js-yaml-3.14.1.tgz",
+      "integrity": "sha1-2ugS/bOCX6MGYJqHFzg8UMNqBTc=",
       "dev": true,
       "dependencies": {
         "argparse": "^1.0.7",
@@ -909,8 +850,8 @@
     },
     "node_modules/@istanbuljs/load-nyc-config/node_modules/locate-path": {
       "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
-      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/locate-path/-/locate-path-5.0.0.tgz",
+      "integrity": "sha1-Gvujlq/WdqbUJQTQpno6frn2KqA=",
       "dev": true,
       "dependencies": {
         "p-locate": "^4.1.0"
@@ -921,8 +862,8 @@
     },
     "node_modules/@istanbuljs/load-nyc-config/node_modules/p-limit": {
       "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha1-PdM8ZHohT9//2DWTPrCG2g3CHbE=",
       "dev": true,
       "dependencies": {
         "p-try": "^2.0.0"
@@ -936,8 +877,8 @@
     },
     "node_modules/@istanbuljs/load-nyc-config/node_modules/p-locate": {
       "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
-      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/p-locate/-/p-locate-4.1.0.tgz",
+      "integrity": "sha1-o0KLtwiLOmApL2aRkni3wpetTwc=",
       "dev": true,
       "dependencies": {
         "p-limit": "^2.2.0"
@@ -948,8 +889,8 @@
     },
     "node_modules/@istanbuljs/load-nyc-config/node_modules/resolve-from": {
       "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
-      "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/resolve-from/-/resolve-from-5.0.0.tgz",
+      "integrity": "sha1-w1IlhD3493bfIcV1V7wIfp39/Gk=",
       "dev": true,
       "engines": {
         "node": ">=8"
@@ -957,8 +898,8 @@
     },
     "node_modules/@istanbuljs/schema": {
       "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.3.tgz",
-      "integrity": "sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@istanbuljs/schema/-/schema-0.1.3.tgz",
+      "integrity": "sha1-5F44TkuOwWvOL9kDr3hFD2v37Jg=",
       "dev": true,
       "engines": {
         "node": ">=8"
@@ -966,8 +907,8 @@
     },
     "node_modules/@jest/console": {
       "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/@jest/console/-/console-29.7.0.tgz",
-      "integrity": "sha512-5Ni4CU7XHQi32IJ398EEP4RrB8eV09sXP2ROqD4bksHrnTree52PsxvX8tpL8LvTZ3pFzXyPbNQReSN41CAhOg==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@jest/console/-/console-29.7.0.tgz",
+      "integrity": "sha1-zUgi29uEUpJlxaK9tSmjycyVD/w=",
       "dev": true,
       "dependencies": {
         "@jest/types": "^29.6.3",
@@ -983,8 +924,8 @@
     },
     "node_modules/@jest/core": {
       "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/@jest/core/-/core-29.7.0.tgz",
-      "integrity": "sha512-n7aeXWKMnGtDA48y8TLWJPJmLmmZ642Ceo78cYWEpiD7FzDgmNDV/GCVRorPABdXLJZ/9wzzgZAlHjXjxDHGsg==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@jest/core/-/core-29.7.0.tgz",
+      "integrity": "sha1-tszMI58w/zZglljFpeIpF1fORI8=",
       "dev": true,
       "dependencies": {
         "@jest/console": "^29.7.0",
@@ -1030,8 +971,8 @@
     },
     "node_modules/@jest/environment": {
       "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-29.7.0.tgz",
-      "integrity": "sha512-aQIfHDq33ExsN4jP1NWGXhxgQ/wixs60gDiKO+XVMd8Mn0NWPWgc34ZQDTb2jKaUWQ7MuwoitXAsN2XVXNMpAw==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@jest/environment/-/environment-29.7.0.tgz",
+      "integrity": "sha1-JNYfVP8feG881Ac7S5RBY4O68qc=",
       "dev": true,
       "dependencies": {
         "@jest/fake-timers": "^29.7.0",
@@ -1045,8 +986,8 @@
     },
     "node_modules/@jest/expect": {
       "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/@jest/expect/-/expect-29.7.0.tgz",
-      "integrity": "sha512-8uMeAMycttpva3P1lBHB8VciS9V0XAr3GymPpipdyQXbBcuhkLQOSe8E/p92RyAdToS6ZD1tFkX+CkhoECE0dQ==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@jest/expect/-/expect-29.7.0.tgz",
+      "integrity": "sha1-dqPtsMt1O3Dfv+Iyg1ENPUVDK/I=",
       "dev": true,
       "dependencies": {
         "expect": "^29.7.0",
@@ -1058,8 +999,8 @@
     },
     "node_modules/@jest/expect-utils": {
       "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-29.7.0.tgz",
-      "integrity": "sha512-GlsNBWiFQFCVi9QVSx7f5AgMeLxe9YCCs5PuP2O2LdjDAA8Jh9eX7lA1Jq/xdXw3Wb3hyvlFNfZIfcRetSzYcA==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@jest/expect-utils/-/expect-utils-29.7.0.tgz",
+      "integrity": "sha1-Aj7+XSaopw8hZ30KGvwPCkTjocY=",
       "dev": true,
       "dependencies": {
         "jest-get-type": "^29.6.3"
@@ -1070,8 +1011,8 @@
     },
     "node_modules/@jest/fake-timers": {
       "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-29.7.0.tgz",
-      "integrity": "sha512-q4DH1Ha4TTFPdxLsqDXK1d3+ioSL7yL5oCMJZgDYm6i+6CygW5E5xVr/D1HdsGxjt1ZWSfUAs9OxSB/BNelWrQ==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@jest/fake-timers/-/fake-timers-29.7.0.tgz",
+      "integrity": "sha1-/ZG/H/+xbX0NJKQmqxpHpJiBpWU=",
       "dev": true,
       "dependencies": {
         "@jest/types": "^29.6.3",
@@ -1087,8 +1028,8 @@
     },
     "node_modules/@jest/globals": {
       "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-29.7.0.tgz",
-      "integrity": "sha512-mpiz3dutLbkW2MNFubUGUEVLkTGiqW6yLVTA+JbP6fI6J5iL9Y0Nlg8k95pcF8ctKwCS7WVxteBs29hhfAotzQ==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@jest/globals/-/globals-29.7.0.tgz",
+      "integrity": "sha1-jZKQ+exH/3cmB/qGTKHVou+uHU0=",
       "dev": true,
       "dependencies": {
         "@jest/environment": "^29.7.0",
@@ -1102,8 +1043,8 @@
     },
     "node_modules/@jest/reporters": {
       "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-29.7.0.tgz",
-      "integrity": "sha512-DApq0KJbJOEzAFYjHADNNxAE3KbhxQB1y5Kplb5Waqw6zVbuWatSnMjE5gs8FUgEPmNsnZA3NCWl9NG0ia04Pg==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@jest/reporters/-/reporters-29.7.0.tgz",
+      "integrity": "sha1-BLJi7LO4+qg7Cz0yFiOXI5Po9Mc=",
       "dev": true,
       "dependencies": {
         "@bcoe/v8-coverage": "^0.2.3",
@@ -1145,8 +1086,8 @@
     },
     "node_modules/@jest/schemas": {
       "version": "29.6.3",
-      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
-      "integrity": "sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@jest/schemas/-/schemas-29.6.3.tgz",
+      "integrity": "sha1-Qwtc6KTgBEp+OBlmMwWnswkcjgM=",
       "dev": true,
       "dependencies": {
         "@sinclair/typebox": "^0.27.8"
@@ -1157,8 +1098,8 @@
     },
     "node_modules/@jest/source-map": {
       "version": "29.6.3",
-      "resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-29.6.3.tgz",
-      "integrity": "sha512-MHjT95QuipcPrpLM+8JMSzFx6eHp5Bm+4XeFDJlwsvVBjmKNiIAvasGK2fxz2WbGRlnvqehFbh07MMa7n3YJnw==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@jest/source-map/-/source-map-29.6.3.tgz",
+      "integrity": "sha1-2Quncglc83o0peuUE/G1YqCFVMQ=",
       "dev": true,
       "dependencies": {
         "@jridgewell/trace-mapping": "^0.3.18",
@@ -1171,8 +1112,8 @@
     },
     "node_modules/@jest/test-result": {
       "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-29.7.0.tgz",
-      "integrity": "sha512-Fdx+tv6x1zlkJPcWXmMDAG2HBnaR9XPSd5aDWQVsfrZmLVT3lU1cwyxLgRmXR9yrq4NBoEm9BMsfgFzTQAbJYA==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@jest/test-result/-/test-result-29.7.0.tgz",
+      "integrity": "sha1-jbmoCqGgl7siYlcmhnNLrtmxZXw=",
       "dev": true,
       "dependencies": {
         "@jest/console": "^29.7.0",
@@ -1186,8 +1127,8 @@
     },
     "node_modules/@jest/test-sequencer": {
       "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-29.7.0.tgz",
-      "integrity": "sha512-GQwJ5WZVrKnOJuiYiAF52UNUJXgTZx1NHjFSEB0qEMmSZKAkdMoIzw/Cj6x6NF4AvV23AUqDpFzQkN/eYCYTxw==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@jest/test-sequencer/-/test-sequencer-29.7.0.tgz",
+      "integrity": "sha1-bO+XfOHTmDSjrqiHoXJmKKbwcs4=",
       "dev": true,
       "dependencies": {
         "@jest/test-result": "^29.7.0",
@@ -1201,8 +1142,8 @@
     },
     "node_modules/@jest/transform": {
       "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-29.7.0.tgz",
-      "integrity": "sha512-ok/BTPFzFKVMwO5eOHRrvnBVHdRy9IrsrW1GpMaQ9MCnilNLXQKmAX8s1YXDFaai9xJpac2ySzV0YeRRECr2Vw==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@jest/transform/-/transform-29.7.0.tgz",
+      "integrity": "sha1-3y3Zw0bH13aLigZjmZRkDGQuKEw=",
       "dev": true,
       "dependencies": {
         "@babel/core": "^7.11.6",
@@ -1227,8 +1168,8 @@
     },
     "node_modules/@jest/types": {
       "version": "29.6.3",
-      "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.6.3.tgz",
-      "integrity": "sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@jest/types/-/types-29.6.3.tgz",
+      "integrity": "sha1-ETH4z2NOfoTF53urEvBSr1hfulk=",
       "dev": true,
       "dependencies": {
         "@jest/schemas": "^29.6.3",
@@ -1243,32 +1184,32 @@
       }
     },
     "node_modules/@jridgewell/gen-mapping": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.3.tgz",
-      "integrity": "sha512-HLhSWOLRi875zjjMG/r+Nv0oCW8umGb0BgEhyX3dDX3egwZtB8PqLnjz3yedt8R5StBrzcg4aBpnh8UA9D1BoQ==",
+      "version": "0.3.5",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@jridgewell/gen-mapping/-/gen-mapping-0.3.5.tgz",
+      "integrity": "sha1-3M5q/3S99trRqVgCtpsEovyx+zY=",
       "dev": true,
       "dependencies": {
-        "@jridgewell/set-array": "^1.0.1",
+        "@jridgewell/set-array": "^1.2.1",
         "@jridgewell/sourcemap-codec": "^1.4.10",
-        "@jridgewell/trace-mapping": "^0.3.9"
+        "@jridgewell/trace-mapping": "^0.3.24"
       },
       "engines": {
         "node": ">=6.0.0"
       }
     },
     "node_modules/@jridgewell/resolve-uri": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.1.tgz",
-      "integrity": "sha512-dSYZh7HhCDtCKm4QakX0xFpsRDqjjtZf/kjI/v3T3Nwt5r8/qz/M19F9ySyOqU94SXBmeG9ttTul+YnR4LOxFA==",
+      "version": "3.1.2",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha1-eg7mAfYPmaIMfHxf8MgDiMEYm9Y=",
       "dev": true,
       "engines": {
         "node": ">=6.0.0"
       }
     },
     "node_modules/@jridgewell/set-array": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.1.2.tgz",
-      "integrity": "sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==",
+      "version": "1.2.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@jridgewell/set-array/-/set-array-1.2.1.tgz",
+      "integrity": "sha1-VY+2Ry7RakyFC4iVMOazZDjEkoA=",
       "dev": true,
       "engines": {
         "node": ">=6.0.0"
@@ -1276,14 +1217,14 @@
     },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.4.15",
-      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz",
-      "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz",
+      "integrity": "sha1-18bmdVx4VnqVHgSrUu8P0m3lnzI=",
       "dev": true
     },
     "node_modules/@jridgewell/trace-mapping": {
-      "version": "0.3.20",
-      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.20.tgz",
-      "integrity": "sha512-R8LcPeWZol2zR8mmH3JeKQ6QRCFb7XgUhV9ZlGhHLGyg4wpPiPZNQOOWhFZhxKw8u//yTbNGI42Bx/3paXEQ+Q==",
+      "version": "0.3.25",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@jridgewell/trace-mapping/-/trace-mapping-0.3.25.tgz",
+      "integrity": "sha1-FfGQ6YiV8/wjJ27hS8drZ1wuUPA=",
       "dev": true,
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
@@ -1292,8 +1233,8 @@
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
-      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
-      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+      "integrity": "sha1-dhnC6yGyVIP20WdUi0z9WnSIw9U=",
       "dev": true,
       "dependencies": {
         "@nodelib/fs.stat": "2.0.5",
@@ -1305,8 +1246,8 @@
     },
     "node_modules/@nodelib/fs.stat": {
       "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
-      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+      "integrity": "sha1-W9Jir5Tp0lvR5xsF3u1Eh2oiLos=",
       "dev": true,
       "engines": {
         "node": ">= 8"
@@ -1314,8 +1255,8 @@
     },
     "node_modules/@nodelib/fs.walk": {
       "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
-      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+      "integrity": "sha1-6Vc36LtnRt3t9pxVaVNJTxlv5po=",
       "dev": true,
       "dependencies": {
         "@nodelib/fs.scandir": "2.1.5",
@@ -1327,14 +1268,14 @@
     },
     "node_modules/@sinclair/typebox": {
       "version": "0.27.8",
-      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
-      "integrity": "sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@sinclair/typebox/-/typebox-0.27.8.tgz",
+      "integrity": "sha1-Zmf6wWxDa1Q0o4ejTe2wExmPbm4=",
       "dev": true
     },
     "node_modules/@sinonjs/commons": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-3.0.0.tgz",
-      "integrity": "sha512-jXBtWAF4vmdNmZgD5FoKsVLv3rPgDnLgPbU84LIJ3otV44vJlDRokVng5v8NFJdCf/da9legHcKaRuZs4L7faA==",
+      "version": "3.0.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@sinonjs/commons/-/commons-3.0.1.tgz",
+      "integrity": "sha1-ECk1fkTKkBphVYX20nc428iQhM0=",
       "dev": true,
       "dependencies": {
         "type-detect": "4.0.8"
@@ -1342,17 +1283,17 @@
     },
     "node_modules/@sinonjs/fake-timers": {
       "version": "10.3.0",
-      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-10.3.0.tgz",
-      "integrity": "sha512-V4BG07kuYSUkTCSBHG8G8TNhM+F19jXFWnQtzj+we8DrkpSBCee9Z3Ms8yiGer/dlmhe35/Xdgyo3/0rQKg7YA==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@sinonjs/fake-timers/-/fake-timers-10.3.0.tgz",
+      "integrity": "sha1-Vf3/Hsq581QBkSna9N8N1Nkj6mY=",
       "dev": true,
       "dependencies": {
         "@sinonjs/commons": "^3.0.0"
       }
     },
     "node_modules/@types/babel__core": {
-      "version": "7.20.3",
-      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.3.tgz",
-      "integrity": "sha512-54fjTSeSHwfan8AyHWrKbfBWiEUrNTZsUwPTDSNaaP1QDQIZbeNUg3a59E9D+375MzUw/x1vx2/0F5LBz+AeYA==",
+      "version": "7.20.5",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@types/babel__core/-/babel__core-7.20.5.tgz",
+      "integrity": "sha1-PfFfJ7qFMZyqB7oI0HIYibs5wBc=",
       "dev": true,
       "dependencies": {
         "@babel/parser": "^7.20.7",
@@ -1363,18 +1304,18 @@
       }
     },
     "node_modules/@types/babel__generator": {
-      "version": "7.6.6",
-      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.6.6.tgz",
-      "integrity": "sha512-66BXMKb/sUWbMdBNdMvajU7i/44RkrA3z/Yt1c7R5xejt8qh84iU54yUWCtm0QwGJlDcf/gg4zd/x4mpLAlb/w==",
+      "version": "7.6.8",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@types/babel__generator/-/babel__generator-7.6.8.tgz",
+      "integrity": "sha1-+DbGH0ixNG59Kw2TxtrMW5U106s=",
       "dev": true,
       "dependencies": {
         "@babel/types": "^7.0.0"
       }
     },
     "node_modules/@types/babel__template": {
-      "version": "7.4.3",
-      "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.3.tgz",
-      "integrity": "sha512-ciwyCLeuRfxboZ4isgdNZi/tkt06m8Tw6uGbBSBgWrnnZGNXiEyM27xc/PjXGQLqlZ6ylbgHMnm7ccF9tCkOeQ==",
+      "version": "7.4.4",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@types/babel__template/-/babel__template-7.4.4.tgz",
+      "integrity": "sha1-VnJRNwHBshmbxtrWNqnXSRWGdm8=",
       "dev": true,
       "dependencies": {
         "@babel/parser": "^7.1.0",
@@ -1382,42 +1323,42 @@
       }
     },
     "node_modules/@types/babel__traverse": {
-      "version": "7.20.3",
-      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.20.3.tgz",
-      "integrity": "sha512-Lsh766rGEFbaxMIDH7Qa+Yha8cMVI3qAK6CHt3OR0YfxOIn5Z54iHiyDRycHrBqeIiqGa20Kpsv1cavfBKkRSw==",
+      "version": "7.20.6",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@types/babel__traverse/-/babel__traverse-7.20.6.tgz",
+      "integrity": "sha1-jcnwrg8gLAjY1Nq2SJEsjWA44/c=",
       "dev": true,
       "dependencies": {
         "@babel/types": "^7.20.7"
       }
     },
     "node_modules/@types/graceful-fs": {
-      "version": "4.1.8",
-      "resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.8.tgz",
-      "integrity": "sha512-NhRH7YzWq8WiNKVavKPBmtLYZHxNY19Hh+az28O/phfp68CF45pMFud+ZzJ8ewnxnC5smIdF3dqFeiSUQ5I+pw==",
+      "version": "4.1.9",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@types/graceful-fs/-/graceful-fs-4.1.9.tgz",
+      "integrity": "sha1-Kga8D2iiCrN7PjaqI4vmq99J6LQ=",
       "dev": true,
       "dependencies": {
         "@types/node": "*"
       }
     },
     "node_modules/@types/istanbul-lib-coverage": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.5.tgz",
-      "integrity": "sha512-zONci81DZYCZjiLe0r6equvZut0b+dBRPBN5kBDjsONnutYNtJMoWQ9uR2RkL1gLG9NMTzvf+29e5RFfPbeKhQ==",
+      "version": "2.0.6",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.6.tgz",
+      "integrity": "sha1-dznCMqH+6bTTzomF8xTAxtM1Sdc=",
       "dev": true
     },
     "node_modules/@types/istanbul-lib-report": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-report/-/istanbul-lib-report-3.0.2.tgz",
-      "integrity": "sha512-8toY6FgdltSdONav1XtUHl4LN1yTmLza+EuDazb/fEmRNCwjyqNVIQWs2IfC74IqjHkREs/nQ2FWq5kZU9IC0w==",
+      "version": "3.0.3",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@types/istanbul-lib-report/-/istanbul-lib-report-3.0.3.tgz",
+      "integrity": "sha1-UwR2FK5y4Z/AQB2HLeOuK0zjUL8=",
       "dev": true,
       "dependencies": {
         "@types/istanbul-lib-coverage": "*"
       }
     },
     "node_modules/@types/istanbul-reports": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.3.tgz",
-      "integrity": "sha512-1nESsePMBlf0RPRffLZi5ujYh7IH1BWL4y9pr+Bn3cJBdxz+RTP8bUFljLz9HvzhhOSWKdyBZ4DIivdL6rvgZg==",
+      "version": "3.0.4",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@types/istanbul-reports/-/istanbul-reports-3.0.4.tgz",
+      "integrity": "sha1-DwPj0vZw+9rFhuNLQzeDBwzBb1Q=",
       "dev": true,
       "dependencies": {
         "@types/istanbul-lib-report": "*"
@@ -1425,52 +1366,50 @@
     },
     "node_modules/@types/json5": {
       "version": "0.0.29",
-      "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
-      "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@types/json5/-/json5-0.0.29.tgz",
+      "integrity": "sha1-7ihweulOEdK4J7y+UnC86n8+ce4=",
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "20.8.7",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.8.7.tgz",
-      "integrity": "sha512-21TKHHh3eUHIi2MloeptJWALuCu5H7HQTdTrWIFReA8ad+aggoX+lRes3ex7/FtpC+sVUpFMQ+QTfYr74mruiQ==",
+      "version": "20.12.12",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@types/node/-/node-20.12.12.tgz",
+      "integrity": "sha1-fL7N+QIIXOxjT9s2IXLf4SuPIFA=",
       "dev": true,
       "dependencies": {
-        "undici-types": "~5.25.1"
+        "undici-types": "~5.26.4"
       }
     },
     "node_modules/@types/stack-utils": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.2.tgz",
-      "integrity": "sha512-g7CK9nHdwjK2n0ymT2CW698FuWJRIx+RP6embAzZ2Qi8/ilIrA1Imt2LVSeHUzKvpoi7BhmmQcXz95eS0f2JXw==",
+      "version": "2.0.3",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@types/stack-utils/-/stack-utils-2.0.3.tgz",
+      "integrity": "sha1-YgkyHrLBcSp+dGZCK4yx/A2d1dg=",
       "dev": true
     },
     "node_modules/@types/yargs": {
-      "version": "17.0.29",
-      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.29.tgz",
-      "integrity": "sha512-nacjqA3ee9zRF/++a3FUY1suHTFKZeHba2n8WeDw9cCVdmzmHpIxyzOJBcpHvvEmS8E9KqWlSnWHUkOrkhWcvA==",
+      "version": "17.0.32",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@types/yargs/-/yargs-17.0.32.tgz",
+      "integrity": "sha1-Awd0cjovf6r+v2RfTlpINx3KYik=",
       "dev": true,
       "dependencies": {
         "@types/yargs-parser": "*"
       }
     },
     "node_modules/@types/yargs-parser": {
-      "version": "21.0.2",
-      "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-21.0.2.tgz",
-      "integrity": "sha512-5qcvofLPbfjmBfKaLfj/+f+Sbd6pN4zl7w7VSVI5uz7m9QZTuB2aZAa2uo1wHFBNN2x6g/SoTkXmd8mQnQF2Cw==",
+      "version": "21.0.3",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@types/yargs-parser/-/yargs-parser-21.0.3.tgz",
+      "integrity": "sha1-gV4wt4bS6PDc2F/VvPXhoE0AjxU=",
       "dev": true
     },
-    "node_modules/@xmldom/xmldom": {
-      "version": "0.8.10",
-      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.10.tgz",
-      "integrity": "sha512-2WALfTl4xo2SkGCYRt6rDTFfk9R1czmBvUQy12gK2KuRKIpWEhcbbzy8EZXtz/jkRqHX8bFEc6FC1HjX4TUWYw==",
-      "engines": {
-        "node": ">=10.0.0"
-      }
+    "node_modules/@ungap/structured-clone": {
+      "version": "1.2.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@ungap/structured-clone/-/structured-clone-1.2.0.tgz",
+      "integrity": "sha1-dWZBrbWHhRtcyz4JXa8nrlgchAY=",
+      "dev": true
     },
     "node_modules/accepts": {
       "version": "1.3.8",
-      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
-      "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/accepts/-/accepts-1.3.8.tgz",
+      "integrity": "sha1-C/C+EltnAUrcsLCSHmLbe//hay4=",
       "dependencies": {
         "mime-types": "~2.1.34",
         "negotiator": "0.6.3"
@@ -1480,9 +1419,9 @@
       }
     },
     "node_modules/acorn": {
-      "version": "8.10.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.10.0.tgz",
-      "integrity": "sha512-F0SAmZ8iUtS//m8DmCTA0jlh6TDKkHQyK6xc6V4KDTyZKA9dnvX9/3sRTVQrWm79glUAZbnmmNcdYwUIHWVybw==",
+      "version": "8.11.3",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/acorn/-/acorn-8.11.3.tgz",
+      "integrity": "sha1-ceCxThOk7BYHJLOPt7DyM7G4HXo=",
       "dev": true,
       "bin": {
         "acorn": "bin/acorn"
@@ -1493,44 +1432,17 @@
     },
     "node_modules/acorn-jsx": {
       "version": "5.3.2",
-      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
-      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha1-ftW7VZCLOy8bxVxq8WU7rafweTc=",
       "dev": true,
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
-    "node_modules/adal-node": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/adal-node/-/adal-node-0.2.4.tgz",
-      "integrity": "sha512-zIcvbwQFKMUtKxxj8YMHeTT1o/TPXfVNsTXVgXD8sxwV6h4AFQgK77dRciGhuEF9/Sdm3UQPJVPc/6XxrccSeA==",
-      "dependencies": {
-        "@xmldom/xmldom": "^0.8.3",
-        "async": "^2.6.3",
-        "axios": "^0.21.1",
-        "date-utils": "*",
-        "jws": "3.x.x",
-        "underscore": ">= 1.3.1",
-        "uuid": "^3.1.0",
-        "xpath.js": "~1.1.0"
-      },
-      "engines": {
-        "node": ">= 0.6.15"
-      }
-    },
-    "node_modules/adal-node/node_modules/uuid": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
-      "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
-      "bin": {
-        "uuid": "bin/uuid"
-      }
-    },
     "node_modules/ajv": {
       "version": "6.12.6",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/ajv/-/ajv-6.12.6.tgz",
+      "integrity": "sha1-uvWmLoArB9l3A0WG+MO69a3ybfQ=",
       "dev": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
@@ -1545,16 +1457,16 @@
     },
     "node_modules/amdefine": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
-      "integrity": "sha512-S2Hw0TtNkMJhIabBwIojKL9YHO5T0n5eNqWJ7Lrlel/zDbftQpxpapi8tZs3X1HWa+u+QeydGmzzNU0m09+Rcg==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/amdefine/-/amdefine-1.0.1.tgz",
+      "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
       "engines": {
         "node": ">=0.4.2"
       }
     },
     "node_modules/ansi-escapes": {
       "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
-      "integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
+      "integrity": "sha1-ayKR0dt9mLZSHV8e+kLQ86n+tl4=",
       "dev": true,
       "dependencies": {
         "type-fest": "^0.21.3"
@@ -1568,8 +1480,8 @@
     },
     "node_modules/ansi-escapes/node_modules/type-fest": {
       "version": "0.21.3",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
-      "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/type-fest/-/type-fest-0.21.3.tgz",
+      "integrity": "sha1-0mCiSwGYQ24TP6JqUkptZfo7Ljc=",
       "dev": true,
       "engines": {
         "node": ">=10"
@@ -1580,16 +1492,16 @@
     },
     "node_modules/ansi-regex": {
       "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha1-CCyyyJyf6GWaMRpTvWpNxTAdswQ=",
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/ansi-styles": {
       "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha1-7dgDYornHATIWuegkG7a00tkiTc=",
       "dependencies": {
         "color-convert": "^2.0.1"
       },
@@ -1602,8 +1514,8 @@
     },
     "node_modules/anymatch": {
       "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
-      "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/anymatch/-/anymatch-3.1.3.tgz",
+      "integrity": "sha1-eQxYsZuhcgqEIFtXxhjVrYUklz4=",
       "dev": true,
       "dependencies": {
         "normalize-path": "^3.0.0",
@@ -1615,18 +1527,21 @@
     },
     "node_modules/argparse": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha1-JG9Q88p4oyQPbJl+ipvR6sSeSzg=",
       "dev": true
     },
     "node_modules/array-buffer-byte-length": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/array-buffer-byte-length/-/array-buffer-byte-length-1.0.0.tgz",
-      "integrity": "sha512-LPuwb2P+NrQw3XhxGc36+XSvuBPopovXYTR9Ew++Du9Yb/bx5AzBfrIsBoj0EZUifjQU+sHL21sseZ3jerWO/A==",
+      "version": "1.0.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/array-buffer-byte-length/-/array-buffer-byte-length-1.0.1.tgz",
+      "integrity": "sha1-HlWD7BZ2NUCieuUu7Zn/iZIjVo8=",
       "dev": true,
       "dependencies": {
-        "call-bind": "^1.0.2",
-        "is-array-buffer": "^3.0.1"
+        "call-bind": "^1.0.5",
+        "is-array-buffer": "^3.0.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -1634,19 +1549,20 @@
     },
     "node_modules/array-flatten": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
-      "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg=="
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/array-flatten/-/array-flatten-1.1.1.tgz",
+      "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI="
     },
     "node_modules/array-includes": {
-      "version": "3.1.7",
-      "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.7.tgz",
-      "integrity": "sha512-dlcsNBIiWhPkHdOEEKnehA+RNUWDc4UqFtnIXU4uuYDPtA4LDkr7qip2p0VvFAEXNDr0yWZ9PJyIRiGjRLQzwQ==",
+      "version": "3.1.8",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/array-includes/-/array-includes-3.1.8.tgz",
+      "integrity": "sha1-XjcMvhcv3V3WUwwdSq3aJSgbqX0=",
       "dev": true,
       "dependencies": {
-        "call-bind": "^1.0.2",
-        "define-properties": "^1.2.0",
-        "es-abstract": "^1.22.1",
-        "get-intrinsic": "^1.2.1",
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.2",
+        "es-object-atoms": "^1.0.0",
+        "get-intrinsic": "^1.2.4",
         "is-string": "^1.0.7"
       },
       "engines": {
@@ -1657,16 +1573,17 @@
       }
     },
     "node_modules/array.prototype.findlastindex": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/array.prototype.findlastindex/-/array.prototype.findlastindex-1.2.3.tgz",
-      "integrity": "sha512-LzLoiOMAxvy+Gd3BAq3B7VeIgPdo+Q8hthvKtXybMvRV0jrXfJM/t8mw7nNlpEcVlVUnCnM2KSX4XU5HmpodOA==",
+      "version": "1.2.5",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/array.prototype.findlastindex/-/array.prototype.findlastindex-1.2.5.tgz",
+      "integrity": "sha1-jDWnVccpCHGUU/hxRcoBHjkzTQ0=",
       "dev": true,
       "dependencies": {
-        "call-bind": "^1.0.2",
-        "define-properties": "^1.2.0",
-        "es-abstract": "^1.22.1",
-        "es-shim-unscopables": "^1.0.0",
-        "get-intrinsic": "^1.2.1"
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.2",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.0.0",
+        "es-shim-unscopables": "^1.0.2"
       },
       "engines": {
         "node": ">= 0.4"
@@ -1677,8 +1594,8 @@
     },
     "node_modules/array.prototype.flat": {
       "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.3.2.tgz",
-      "integrity": "sha512-djYB+Zx2vLewY8RWlNCUdHjDXs2XOgm602S9E7P/UpHgfeHL00cRiIF+IN/G/aUJ7kGPb6yO/ErDI5V2s8iycA==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/array.prototype.flat/-/array.prototype.flat-1.3.2.tgz",
+      "integrity": "sha1-FHYhffjP8X1y7o87oGc421s4fRg=",
       "dev": true,
       "dependencies": {
         "call-bind": "^1.0.2",
@@ -1695,8 +1612,8 @@
     },
     "node_modules/array.prototype.flatmap": {
       "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/array.prototype.flatmap/-/array.prototype.flatmap-1.3.2.tgz",
-      "integrity": "sha512-Ewyx0c9PmpcsByhSW4r+9zDU7sGjFc86qf/kKtuSCRdhfbk0SNLLkaT5qvcHnRGgc5NP/ly/y+qkXkqONX54CQ==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/array.prototype.flatmap/-/array.prototype.flatmap-1.3.2.tgz",
+      "integrity": "sha1-yafGgx245xnWzmORkBRsJLvT5Sc=",
       "dev": true,
       "dependencies": {
         "call-bind": "^1.0.2",
@@ -1712,17 +1629,18 @@
       }
     },
     "node_modules/arraybuffer.prototype.slice": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/arraybuffer.prototype.slice/-/arraybuffer.prototype.slice-1.0.2.tgz",
-      "integrity": "sha512-yMBKppFur/fbHu9/6USUe03bZ4knMYiwFBcyiaXB8Go0qNehwX6inYPzK9U0NeQvGxKthcmHcaR8P5MStSRBAw==",
+      "version": "1.0.3",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/arraybuffer.prototype.slice/-/arraybuffer.prototype.slice-1.0.3.tgz",
+      "integrity": "sha1-CXly9CVeQbw0JeN9w/ZCHPmu/eY=",
       "dev": true,
       "dependencies": {
-        "array-buffer-byte-length": "^1.0.0",
-        "call-bind": "^1.0.2",
-        "define-properties": "^1.2.0",
-        "es-abstract": "^1.22.1",
-        "get-intrinsic": "^1.2.1",
-        "is-array-buffer": "^3.0.2",
+        "array-buffer-byte-length": "^1.0.1",
+        "call-bind": "^1.0.5",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.22.3",
+        "es-errors": "^1.2.1",
+        "get-intrinsic": "^1.2.3",
+        "is-array-buffer": "^3.0.4",
         "is-shared-array-buffer": "^1.0.2"
       },
       "engines": {
@@ -1734,26 +1652,18 @@
     },
     "node_modules/asap": {
       "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
-      "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA=="
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/asap/-/asap-2.0.6.tgz",
+      "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
     },
     "node_modules/assert-never": {
       "version": "1.2.1",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/assert-never/-/assert-never-1.2.1.tgz",
       "integrity": "sha1-EfDjY78UYgX7CBk7XHuQ9NHPRP4="
     },
-    "node_modules/async": {
-      "version": "2.6.4",
-      "resolved": "https://registry.npmjs.org/async/-/async-2.6.4.tgz",
-      "integrity": "sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==",
-      "dependencies": {
-        "lodash": "^4.17.14"
-      }
-    },
     "node_modules/atob": {
       "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
-      "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/atob/-/atob-2.1.2.tgz",
+      "integrity": "sha1-bZUX654DDSQ2ZmZR6GvZ9vE1M8k=",
       "bin": {
         "atob": "bin/atob.js"
       },
@@ -1762,10 +1672,13 @@
       }
     },
     "node_modules/available-typed-arrays": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz",
-      "integrity": "sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==",
+      "version": "1.0.7",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
+      "integrity": "sha1-pcw3XWoDwu/IelU/PgsVIt7xSEY=",
       "dev": true,
+      "dependencies": {
+        "possible-typed-array-names": "^1.0.0"
+      },
       "engines": {
         "node": ">= 0.4"
       },
@@ -1773,18 +1686,10 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/axios": {
-      "version": "0.21.4",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/axios/-/axios-0.21.4.tgz",
-      "integrity": "sha1-xnuQ3AVo5cHPKwuFjEO6KOLtpXU=",
-      "dependencies": {
-        "follow-redirects": "^1.14.0"
-      }
-    },
     "node_modules/babel-jest": {
       "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-29.7.0.tgz",
-      "integrity": "sha512-BrvGY3xZSwEcCzKvKsCi2GgHqDqsYkOP4/by5xCgIwGXQxIEh+8ew3gmrE1y7XRR6LHZIj6yLYnUi/mm2KXKBg==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/babel-jest/-/babel-jest-29.7.0.tgz",
+      "integrity": "sha1-9DaZGSJbaExWCFmYrGPb0FvgINU=",
       "dev": true,
       "dependencies": {
         "@jest/transform": "^29.7.0",
@@ -1804,8 +1709,8 @@
     },
     "node_modules/babel-plugin-istanbul": {
       "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-6.1.1.tgz",
-      "integrity": "sha512-Y1IQok9821cC9onCx5otgFfRm7Lm+I+wwxOx738M/WLPZ9Q42m4IG5W0FNX8WLL2gYMZo3JkuXIH2DOpWM+qwA==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/babel-plugin-istanbul/-/babel-plugin-istanbul-6.1.1.tgz",
+      "integrity": "sha1-+ojsWSMv2bTjbbvFQKjsmptH2nM=",
       "dev": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.0.0",
@@ -1820,8 +1725,8 @@
     },
     "node_modules/babel-plugin-istanbul/node_modules/istanbul-lib-instrument": {
       "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-5.2.1.tgz",
-      "integrity": "sha512-pzqtp31nLv/XFOzXGuvhCb8qhjmTVo5vjVk19XE4CRlSWz0KoeJ3bw9XsA7nOp9YBf4qHjwBxkDzKcME/J29Yg==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/istanbul-lib-instrument/-/istanbul-lib-instrument-5.2.1.tgz",
+      "integrity": "sha1-0QyIhcISVXThwjHKyt+VVnXhzj0=",
       "dev": true,
       "dependencies": {
         "@babel/core": "^7.12.3",
@@ -1836,8 +1741,8 @@
     },
     "node_modules/babel-plugin-jest-hoist": {
       "version": "29.6.3",
-      "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-29.6.3.tgz",
-      "integrity": "sha512-ESAc/RJvGTFEzRwOTT4+lNDk/GNHMkKbNzsvT0qKRfDyyYTskxB5rnU2njIDYVxXCBHHEI1c0YwHob3WaYujOg==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-29.6.3.tgz",
+      "integrity": "sha1-qtvpQ0ZBgqiSLDySfDBn/0DSRiY=",
       "dev": true,
       "dependencies": {
         "@babel/template": "^7.3.3",
@@ -1851,8 +1756,8 @@
     },
     "node_modules/babel-preset-current-node-syntax": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/babel-preset-current-node-syntax/-/babel-preset-current-node-syntax-1.0.1.tgz",
-      "integrity": "sha512-M7LQ0bxarkxQoN+vz5aJPsLBn77n8QgTFmo8WK0/44auK2xlCXrYcUxHFxgU7qW5Yzw/CjmLRK2uJzaCd7LvqQ==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/babel-preset-current-node-syntax/-/babel-preset-current-node-syntax-1.0.1.tgz",
+      "integrity": "sha1-tDmSObibKgEfndvj5PQB/EDP9zs=",
       "dev": true,
       "dependencies": {
         "@babel/plugin-syntax-async-generators": "^7.8.4",
@@ -1874,8 +1779,8 @@
     },
     "node_modules/babel-preset-jest": {
       "version": "29.6.3",
-      "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-29.6.3.tgz",
-      "integrity": "sha512-0B3bhxR6snWXJZtR/RliHTDPRgn1sNHOR0yVtq/IiQFyuOVjFS+wuio/R4gSNkyYmKmJB4wGZv2NZanmKmTnNA==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/babel-preset-jest/-/babel-preset-jest-29.6.3.tgz",
+      "integrity": "sha1-+gX6UQ59STiW17DdIDNgHIQPFxw=",
       "dev": true,
       "dependencies": {
         "babel-plugin-jest-hoist": "^29.6.3",
@@ -1901,13 +1806,13 @@
     },
     "node_modules/balanced-match": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha1-6D46fj8wCzTLnYf2FfoMvzV2kO4="
     },
     "node_modules/body-parser": {
       "version": "1.20.2",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.2.tgz",
-      "integrity": "sha512-ml9pReCu3M61kGlqoTm2umSXTlRTuGTx0bfYj+uIUKKYycG5NtSbeetV3faSU6R7ajOPw0g/J1PvK4qNy7s5bA==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/body-parser/-/body-parser-1.20.2.tgz",
+      "integrity": "sha1-b+sOIcRyTQbef/ONo22tT1enR/0=",
       "dependencies": {
         "bytes": "3.1.2",
         "content-type": "~1.0.5",
@@ -1929,29 +1834,29 @@
     },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha1-PH/L9SnYcibz0vUrlm/1Jx60Qd0=",
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
       }
     },
     "node_modules/braces": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "version": "3.0.3",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha1-SQMy9AkZRSJy1VqEgK3AxEE1h4k=",
       "dev": true,
       "dependencies": {
-        "fill-range": "^7.0.1"
+        "fill-range": "^7.1.1"
       },
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/browserslist": {
-      "version": "4.22.1",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.22.1.tgz",
-      "integrity": "sha512-FEVc202+2iuClEhZhrWy6ZiAcRLvNMyYcxZ8raemul1DYVOVdFsbqckWLdsixQZCpJlwe77Z3UTalE7jsjnKfQ==",
+      "version": "4.23.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/browserslist/-/browserslist-4.23.0.tgz",
+      "integrity": "sha1-jzrMK75zr3ITOZQwiQ+GxjpWdKs=",
       "dev": true,
       "funding": [
         {
@@ -1968,9 +1873,9 @@
         }
       ],
       "dependencies": {
-        "caniuse-lite": "^1.0.30001541",
-        "electron-to-chromium": "^1.4.535",
-        "node-releases": "^2.0.13",
+        "caniuse-lite": "^1.0.30001587",
+        "electron-to-chromium": "^1.4.668",
+        "node-releases": "^2.0.14",
         "update-browserslist-db": "^1.0.13"
       },
       "bin": {
@@ -1982,8 +1887,8 @@
     },
     "node_modules/bser": {
       "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/bser/-/bser-2.1.1.tgz",
-      "integrity": "sha512-gQxTNE/GAfIIrmHLUE3oJyp5FO6HRBfhjnw4/wMmA63ZGDJnWBmgY/lyQBpnDUkGmAhbSe39tx2d/iTOAfglwQ==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/bser/-/bser-2.1.1.tgz",
+      "integrity": "sha1-5nh9og7OnQeZhTPP2d5vXDj0vAU=",
       "dev": true,
       "dependencies": {
         "node-int64": "^0.4.0"
@@ -1991,30 +1896,36 @@
     },
     "node_modules/buffer-equal-constant-time": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
-      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA=="
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk="
     },
     "node_modules/buffer-from": {
       "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
-      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha1-KxRqb9cugLT1XSVfNe1Zo6mkG9U=",
       "dev": true
     },
     "node_modules/bytes": {
       "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
-      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha1-iwvuuYYFrfGxKPpDhkA8AJ4CIaU=",
       "engines": {
         "node": ">= 0.8"
       }
     },
     "node_modules/call-bind": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
-      "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
+      "version": "1.0.7",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/call-bind/-/call-bind-1.0.7.tgz",
+      "integrity": "sha1-BgFlmcQMVkmMGHadJzC+JCtvo7k=",
       "dependencies": {
-        "function-bind": "^1.1.1",
-        "get-intrinsic": "^1.0.2"
+        "es-define-property": "^1.0.0",
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2",
+        "get-intrinsic": "^1.2.4",
+        "set-function-length": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -2022,8 +1933,8 @@
     },
     "node_modules/callsites": {
       "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
-      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha1-s2MKvYlDQy9Us/BRkjjjPNffL3M=",
       "dev": true,
       "engines": {
         "node": ">=6"
@@ -2031,17 +1942,17 @@
     },
     "node_modules/camelcase": {
       "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
-      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/camelcase/-/camelcase-5.3.1.tgz",
+      "integrity": "sha1-48mzFWnhBoEd8kL3FXJaH0xJQyA=",
       "dev": true,
       "engines": {
         "node": ">=6"
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001551",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001551.tgz",
-      "integrity": "sha512-vtBAez47BoGMMzlbYhfXrMV1kvRF2WP/lqiMuDu1Sb4EE4LKEgjopFDSRtZfdVnslNRpOqV/woE+Xgrwj6VQlg==",
+      "version": "1.0.30001624",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/caniuse-lite/-/caniuse-lite-1.0.30001624.tgz",
+      "integrity": "sha1-DsTI+npG5beFR3xws4pW0LEAWOs=",
       "dev": true,
       "funding": [
         {
@@ -2060,8 +1971,8 @@
     },
     "node_modules/chalk": {
       "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha1-qsTit3NKdAhnrrFr8CqtVWoeegE=",
       "dev": true,
       "dependencies": {
         "ansi-styles": "^4.1.0",
@@ -2076,8 +1987,8 @@
     },
     "node_modules/char-regex": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/char-regex/-/char-regex-1.0.2.tgz",
-      "integrity": "sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/char-regex/-/char-regex-1.0.2.tgz",
+      "integrity": "sha1-10Q1giYhf5ge1Y9Hmx1rzClUXc8=",
       "dev": true,
       "engines": {
         "node": ">=10"
@@ -2085,16 +1996,16 @@
     },
     "node_modules/character-parser": {
       "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/character-parser/-/character-parser-2.2.0.tgz",
-      "integrity": "sha512-+UqJQjFEFaTAs3bNsF2j2kEN1baG/zghZbdqoYEDxGZtJo9LBzl1A+m0D4n3qKx8N2FNv8/Xp6yV9mQmBuptaw==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/character-parser/-/character-parser-2.2.0.tgz",
+      "integrity": "sha1-x84o821LzZdE5f/CxfzeHHMmH8A=",
       "dependencies": {
         "is-regex": "^1.0.3"
       }
     },
     "node_modules/ci-info": {
       "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
-      "integrity": "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/ci-info/-/ci-info-3.9.0.tgz",
+      "integrity": "sha1-QnmmICinsfJi80c/yWBfXiGMWbQ=",
       "dev": true,
       "funding": [
         {
@@ -2107,15 +2018,15 @@
       }
     },
     "node_modules/cjs-module-lexer": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.2.3.tgz",
-      "integrity": "sha512-0TNiGstbQmCFwt4akjjBg5pLRTSyj/PkWQ1ZoO2zntmg9yLqSRxwEa4iCfQLGjqhiqBfOJa7W/E8wfGrTDmlZQ==",
+      "version": "1.3.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/cjs-module-lexer/-/cjs-module-lexer-1.3.1.tgz",
+      "integrity": "sha1-xIU0Guj9mZyk7lry16HJrgHgCZw=",
       "dev": true
     },
     "node_modules/cliui": {
       "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
-      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha1-DASwddsCy/5g3I5s8vVIaxo2CKo=",
       "dependencies": {
         "string-width": "^4.2.0",
         "strip-ansi": "^6.0.1",
@@ -2127,8 +2038,8 @@
     },
     "node_modules/co": {
       "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
-      "integrity": "sha512-QVb0dM5HvG+uaxitm8wONl7jltx8dqhfU33DcqtOZcLSVIKSDDLDi7+0LbAKiyI8hD9u42m2YxXSkMGWThaecQ==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/co/-/co-4.6.0.tgz",
+      "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
       "dev": true,
       "engines": {
         "iojs": ">= 1.0.0",
@@ -2137,14 +2048,14 @@
     },
     "node_modules/collect-v8-coverage": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/collect-v8-coverage/-/collect-v8-coverage-1.0.2.tgz",
-      "integrity": "sha512-lHl4d5/ONEbLlJvaJNtsF/Lz+WvB07u2ycqTYbdrq7UypDXailES4valYb2eWiJFxZlVmpGekfqoxQhzyFdT4Q==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/collect-v8-coverage/-/collect-v8-coverage-1.0.2.tgz",
+      "integrity": "sha1-wLKbzTO80HeaE0TCE2BR5q/T2ek=",
       "dev": true
     },
     "node_modules/color-convert": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha1-ctOmjVmMm9s68q0ehPIdiWq9TeM=",
       "dependencies": {
         "color-name": "~1.1.4"
       },
@@ -2154,24 +2065,24 @@
     },
     "node_modules/color-name": {
       "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha1-wqCah6y95pVD3m9j+jmVyCbFNqI="
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
     },
     "node_modules/confusing-browser-globals": {
       "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/confusing-browser-globals/-/confusing-browser-globals-1.0.11.tgz",
-      "integrity": "sha512-JsPKdmh8ZkmnHxDk55FZ1TqVLvEQTvoByJZRN9jzI0UjxK/QgAmsphz7PGtqgPieQZ/CQcHWXCR7ATDNhGe+YA==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/confusing-browser-globals/-/confusing-browser-globals-1.0.11.tgz",
+      "integrity": "sha1-rkDptXzdORVAiigF69OlWFYI3IE=",
       "dev": true
     },
     "node_modules/constantinople": {
       "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/constantinople/-/constantinople-4.0.1.tgz",
-      "integrity": "sha512-vCrqcSIq4//Gx74TXXCGnHpulY1dskqLTFGDmhrGxzeXL8lF8kvXv6mpNWlJj1uD4DW23D4ljAqbY4RRaaUZIw==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/constantinople/-/constantinople-4.0.1.tgz",
+      "integrity": "sha1-De8RP6Dk3I3oMzGlz3nIsyUhMVE=",
       "dependencies": {
         "@babel/parser": "^7.6.0",
         "@babel/types": "^7.6.1"
@@ -2179,8 +2090,8 @@
     },
     "node_modules/content-disposition": {
       "version": "0.5.4",
-      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
-      "integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/content-disposition/-/content-disposition-0.5.4.tgz",
+      "integrity": "sha1-i4K076yCUSoCuwsdzsnSxejrW/4=",
       "dependencies": {
         "safe-buffer": "5.2.1"
       },
@@ -2190,16 +2101,16 @@
     },
     "node_modules/content-type": {
       "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
-      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha1-i3cxYmVtHRCGeEyPI6VM5tc9eRg=",
       "engines": {
         "node": ">= 0.6"
       }
     },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
-      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha1-S1YPZJ/E6RjdCrdc9JYei8iC2Co=",
       "dev": true
     },
     "node_modules/cookie": {
@@ -2212,13 +2123,13 @@
     },
     "node_modules/cookie-signature": {
       "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
-      "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ=="
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/cookie-signature/-/cookie-signature-1.0.6.tgz",
+      "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw="
     },
     "node_modules/create-jest": {
       "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/create-jest/-/create-jest-29.7.0.tgz",
-      "integrity": "sha512-Adz2bdH0Vq3F53KEMJOoftQFutWCukm6J24wbPWRO4k1kMY7gS7ds/uoJkNuV8wDCtWWnuwGcJwpWcih+zEW1Q==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/create-jest/-/create-jest-29.7.0.tgz",
+      "integrity": "sha1-o1XFs8seGvAroXf+ev1/7uSaUyA=",
       "dev": true,
       "dependencies": {
         "@jest/types": "^29.6.3",
@@ -2238,8 +2149,8 @@
     },
     "node_modules/cross-spawn": {
       "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/cross-spawn/-/cross-spawn-7.0.3.tgz",
+      "integrity": "sha1-9zqFudXUHQRVUcF34ogtSshXKKY=",
       "dev": true,
       "dependencies": {
         "path-key": "^3.1.0",
@@ -2252,8 +2163,8 @@
     },
     "node_modules/css": {
       "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/css/-/css-2.2.4.tgz",
-      "integrity": "sha512-oUnjmWpy0niI3x/mPL8dVEI1l7MnG3+HHyRPHf+YFSbK+svOhXpmSOcDURUh2aOCgl2grzrOPt1nHLuCVFULLw==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/css/-/css-2.2.4.tgz",
+      "integrity": "sha1-xkZ1XHOXHyu6amAeLPL9cbEpiSk=",
       "dependencies": {
         "inherits": "^2.0.3",
         "source-map": "^0.6.1",
@@ -2263,40 +2174,83 @@
     },
     "node_modules/css-parse": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/css-parse/-/css-parse-2.0.0.tgz",
-      "integrity": "sha512-UNIFik2RgSbiTwIW1IsFwXWn6vs+bYdq83LKTSOsx7NJR7WII9dxewkHLltfTLVppoUApHV0118a4RZRI9FLwA==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/css-parse/-/css-parse-2.0.0.tgz",
+      "integrity": "sha1-pGjuZnwW2BzPBcWMONKpfHgNv9Q=",
       "dependencies": {
         "css": "^2.0.0"
       }
     },
-    "node_modules/date-utils": {
-      "version": "1.2.21",
-      "resolved": "https://registry.npmjs.org/date-utils/-/date-utils-1.2.21.tgz",
-      "integrity": "sha512-wJMBjqlwXR0Iv0wUo/lFbhSQ7MmG1hl36iuxuE91kW+5b5sWbase73manEqNH9sOLFAMG83B4ffNKq9/Iq0FVA==",
+    "node_modules/data-view-buffer": {
+      "version": "1.0.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/data-view-buffer/-/data-view-buffer-1.0.1.tgz",
+      "integrity": "sha1-jqYybv7Bei5CYgaW5nHX1ai8ZrI=",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.6",
+        "es-errors": "^1.3.0",
+        "is-data-view": "^1.0.1"
+      },
       "engines": {
-        "node": ">0.4.0"
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/data-view-byte-length": {
+      "version": "1.0.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/data-view-byte-length/-/data-view-byte-length-1.0.1.tgz",
+      "integrity": "sha1-kHIcqV/ygGd+t5N0n84QETR2aeI=",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "es-errors": "^1.3.0",
+        "is-data-view": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/data-view-byte-offset": {
+      "version": "1.0.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/data-view-byte-offset/-/data-view-byte-offset-1.0.0.tgz",
+      "integrity": "sha1-Xgu/tIKO0tG5tADNin0Rm8oP8Yo=",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.6",
+        "es-errors": "^1.3.0",
+        "is-data-view": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/debug": {
       "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
       "dependencies": {
         "ms": "2.0.0"
       }
     },
     "node_modules/decode-uri-component": {
       "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.2.tgz",
-      "integrity": "sha512-FqUYQ+8o158GyGTrMFJms9qh3CqTKvAqgqsTnkLI8sKu0028orqBhxNMFkFen0zGyg6epACD32pjVk58ngIErQ==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/decode-uri-component/-/decode-uri-component-0.2.2.tgz",
+      "integrity": "sha1-5p2+JdN5QRcd1UDgJMREzVGI4ek=",
       "engines": {
         "node": ">=0.10"
       }
     },
     "node_modules/dedent": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/dedent/-/dedent-1.5.1.tgz",
-      "integrity": "sha512-+LxW+KLWxu3HW3M2w2ympwtqPrqYRzU8fqi6Fhd18fBALe15blJPI/I4+UHveMVG6lJqB4JNd4UG0S5cnVHwIg==",
+      "version": "1.5.3",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/dedent/-/dedent-1.5.3.tgz",
+      "integrity": "sha1-ma7hnrm65VpnMncXtuhI0L93flo=",
       "dev": true,
       "peerDependencies": {
         "babel-plugin-macros": "^3.1.0"
@@ -2309,37 +2263,39 @@
     },
     "node_modules/deep-is": {
       "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
-      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/deep-is/-/deep-is-0.1.4.tgz",
+      "integrity": "sha1-pvLc5hL63S7x9Rm3NVHxfoUZmDE=",
       "dev": true
     },
     "node_modules/deepmerge": {
       "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
-      "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/deepmerge/-/deepmerge-4.3.1.tgz",
+      "integrity": "sha1-RLXyFHzTsA1LVhN2hZZvJv0l3Uo=",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/define-data-property": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.1.tgz",
-      "integrity": "sha512-E7uGkTzkk1d0ByLeSc6ZsFS79Axg+m1P/VsgYsxHgiuc3tFSj+MjMIwe90FC4lOAZzNBdY7kkO2P2wKdsQ1vgQ==",
-      "dev": true,
+      "version": "1.1.4",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/define-data-property/-/define-data-property-1.1.4.tgz",
+      "integrity": "sha1-iU3BQbt9MGCuQ2b2oBB+aPvkjF4=",
       "dependencies": {
-        "get-intrinsic": "^1.2.1",
-        "gopd": "^1.0.1",
-        "has-property-descriptors": "^1.0.0"
+        "es-define-property": "^1.0.0",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.0.1"
       },
       "engines": {
         "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/define-properties": {
       "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
-      "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/define-properties/-/define-properties-1.2.1.tgz",
+      "integrity": "sha1-EHgcxhbrlRqAoDS6/Kpzd/avK2w=",
       "dev": true,
       "dependencies": {
         "define-data-property": "^1.0.1",
@@ -2355,24 +2311,24 @@
     },
     "node_modules/denque": {
       "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/denque/-/denque-1.5.1.tgz",
-      "integrity": "sha512-XwE+iZ4D6ZUB7mfYRMb5wByE8L74HCn30FBN7sWnXksWc1LO1bPDl67pBR9o/kC4z/xSNAwkMYcGgqDV3BE3Hw==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/denque/-/denque-1.5.1.tgz",
+      "integrity": "sha1-B/Zw4pyaePj67LJWah4sEZKcXL8=",
       "engines": {
         "node": ">=0.10"
       }
     },
     "node_modules/depd": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
-      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha1-tpYWPMdXVg0JzyLMj60Vcbeedt8=",
       "engines": {
         "node": ">= 0.8"
       }
     },
     "node_modules/destroy": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
-      "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/destroy/-/destroy-1.2.0.tgz",
+      "integrity": "sha1-SANzVQmti+VSk0xn32FPlOZvoBU=",
       "engines": {
         "node": ">= 0.8",
         "npm": "1.2.8000 || >= 1.4.16"
@@ -2380,8 +2336,8 @@
     },
     "node_modules/detect-newline": {
       "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
-      "integrity": "sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/detect-newline/-/detect-newline-3.1.0.tgz",
+      "integrity": "sha1-V29d/GOuGhkv8ZLYrTr2MImRtlE=",
       "dev": true,
       "engines": {
         "node": ">=8"
@@ -2389,8 +2345,8 @@
     },
     "node_modules/diff-sequences": {
       "version": "29.6.3",
-      "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-29.6.3.tgz",
-      "integrity": "sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/diff-sequences/-/diff-sequences-29.6.3.tgz",
+      "integrity": "sha1-Ter4lNEUB8Ue/IQYAS+ecLhOqSE=",
       "dev": true,
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
@@ -2398,8 +2354,8 @@
     },
     "node_modules/doctrine": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
-      "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/doctrine/-/doctrine-3.0.0.tgz",
+      "integrity": "sha1-rd6+rXKmV023g2OdyHoSF3OXOWE=",
       "dev": true,
       "dependencies": {
         "esutils": "^2.0.2"
@@ -2415,27 +2371,27 @@
     },
     "node_modules/ecdsa-sig-formatter": {
       "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
-      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha1-rg8PothQRe8UqBfao86azQSJ5b8=",
       "dependencies": {
         "safe-buffer": "^5.0.1"
       }
     },
     "node_modules/ee-first": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
-      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.559",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.559.tgz",
-      "integrity": "sha512-iS7KhLYCSJbdo3rUSkhDTVuFNCV34RKs2UaB9Ecr7VlqzjjWW//0nfsFF5dtDmyXlZQaDYYtID5fjtC/6lpRug==",
+      "version": "1.4.783",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/electron-to-chromium/-/electron-to-chromium-1.4.783.tgz",
+      "integrity": "sha1-kziHFluLYCWoFmPS2Xz0uFzeJ7I=",
       "dev": true
     },
     "node_modules/emittery": {
       "version": "0.13.1",
-      "resolved": "https://registry.npmjs.org/emittery/-/emittery-0.13.1.tgz",
-      "integrity": "sha512-DeWwawk6r5yR9jFgnDKYt4sLS0LmHJJi3ZOnb5/JdbYwj3nW+FxQnHIjhBKz8YLC7oRNPVM9NQ47I3CVx34eqQ==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/emittery/-/emittery-0.13.1.tgz",
+      "integrity": "sha1-wEuMNFdJDghHrlH87Tr1LTOOPa0=",
       "dev": true,
       "engines": {
         "node": ">=12"
@@ -2446,71 +2402,78 @@
     },
     "node_modules/emoji-regex": {
       "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha1-6Bj9ac5cz8tARZT4QpY79TFkzDc="
     },
     "node_modules/encodeurl": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
-      "integrity": "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/encodeurl/-/encodeurl-1.0.2.tgz",
+      "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k=",
       "engines": {
         "node": ">= 0.8"
       }
     },
     "node_modules/error-ex": {
       "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
-      "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/error-ex/-/error-ex-1.3.2.tgz",
+      "integrity": "sha1-tKxAZIEH/c3PriQvQovqihTU8b8=",
       "dev": true,
       "dependencies": {
         "is-arrayish": "^0.2.1"
       }
     },
     "node_modules/es-abstract": {
-      "version": "1.22.2",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.22.2.tgz",
-      "integrity": "sha512-YoxfFcDmhjOgWPWsV13+2RNjq1F6UQnfs+8TftwNqtzlmFzEXvlUwdrNrYeaizfjQzRMxkZ6ElWMOJIFKdVqwA==",
+      "version": "1.23.3",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/es-abstract/-/es-abstract-1.23.3.tgz",
+      "integrity": "sha1-jwxaNc0hUxJXPFonyH39bIgaCqA=",
       "dev": true,
       "dependencies": {
-        "array-buffer-byte-length": "^1.0.0",
-        "arraybuffer.prototype.slice": "^1.0.2",
-        "available-typed-arrays": "^1.0.5",
-        "call-bind": "^1.0.2",
-        "es-set-tostringtag": "^2.0.1",
+        "array-buffer-byte-length": "^1.0.1",
+        "arraybuffer.prototype.slice": "^1.0.3",
+        "available-typed-arrays": "^1.0.7",
+        "call-bind": "^1.0.7",
+        "data-view-buffer": "^1.0.1",
+        "data-view-byte-length": "^1.0.1",
+        "data-view-byte-offset": "^1.0.0",
+        "es-define-property": "^1.0.0",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.0.0",
+        "es-set-tostringtag": "^2.0.3",
         "es-to-primitive": "^1.2.1",
         "function.prototype.name": "^1.1.6",
-        "get-intrinsic": "^1.2.1",
-        "get-symbol-description": "^1.0.0",
+        "get-intrinsic": "^1.2.4",
+        "get-symbol-description": "^1.0.2",
         "globalthis": "^1.0.3",
         "gopd": "^1.0.1",
-        "has": "^1.0.3",
-        "has-property-descriptors": "^1.0.0",
-        "has-proto": "^1.0.1",
+        "has-property-descriptors": "^1.0.2",
+        "has-proto": "^1.0.3",
         "has-symbols": "^1.0.3",
-        "internal-slot": "^1.0.5",
-        "is-array-buffer": "^3.0.2",
+        "hasown": "^2.0.2",
+        "internal-slot": "^1.0.7",
+        "is-array-buffer": "^3.0.4",
         "is-callable": "^1.2.7",
-        "is-negative-zero": "^2.0.2",
+        "is-data-view": "^1.0.1",
+        "is-negative-zero": "^2.0.3",
         "is-regex": "^1.1.4",
-        "is-shared-array-buffer": "^1.0.2",
+        "is-shared-array-buffer": "^1.0.3",
         "is-string": "^1.0.7",
-        "is-typed-array": "^1.1.12",
+        "is-typed-array": "^1.1.13",
         "is-weakref": "^1.0.2",
-        "object-inspect": "^1.12.3",
+        "object-inspect": "^1.13.1",
         "object-keys": "^1.1.1",
-        "object.assign": "^4.1.4",
-        "regexp.prototype.flags": "^1.5.1",
-        "safe-array-concat": "^1.0.1",
-        "safe-regex-test": "^1.0.0",
-        "string.prototype.trim": "^1.2.8",
-        "string.prototype.trimend": "^1.0.7",
-        "string.prototype.trimstart": "^1.0.7",
-        "typed-array-buffer": "^1.0.0",
-        "typed-array-byte-length": "^1.0.0",
-        "typed-array-byte-offset": "^1.0.0",
-        "typed-array-length": "^1.0.4",
+        "object.assign": "^4.1.5",
+        "regexp.prototype.flags": "^1.5.2",
+        "safe-array-concat": "^1.1.2",
+        "safe-regex-test": "^1.0.3",
+        "string.prototype.trim": "^1.2.9",
+        "string.prototype.trimend": "^1.0.8",
+        "string.prototype.trimstart": "^1.0.8",
+        "typed-array-buffer": "^1.0.2",
+        "typed-array-byte-length": "^1.0.1",
+        "typed-array-byte-offset": "^1.0.2",
+        "typed-array-length": "^1.0.6",
         "unbox-primitive": "^1.0.2",
-        "which-typed-array": "^1.1.11"
+        "which-typed-array": "^1.1.15"
       },
       "engines": {
         "node": ">= 0.4"
@@ -2519,33 +2482,64 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/es-set-tostringtag": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.0.1.tgz",
-      "integrity": "sha512-g3OMbtlwY3QewlqAiMLI47KywjWZoEytKr8pf6iTC8uJq5bIAH52Z9pnQ8pVL6whrCto53JZDuUIsifGeLorTg==",
+    "node_modules/es-define-property": {
+      "version": "1.0.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/es-define-property/-/es-define-property-1.0.0.tgz",
+      "integrity": "sha1-x/rvvf+LJpbPX0aSHt+3fMS6OEU=",
+      "dependencies": {
+        "get-intrinsic": "^1.2.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha1-BfdaJdq5jk+x3NXhRywFRtUFfI8=",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.0.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/es-object-atoms/-/es-object-atoms-1.0.0.tgz",
+      "integrity": "sha1-3bVc1HrC4kBwEmC8Ko4x7LZD2UE=",
       "dev": true,
       "dependencies": {
-        "get-intrinsic": "^1.1.3",
-        "has": "^1.0.3",
-        "has-tostringtag": "^1.0.0"
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.0.3",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/es-set-tostringtag/-/es-set-tostringtag-2.0.3.tgz",
+      "integrity": "sha1-i7YPCkQMLkKBliQoQ41YVFrzl3c=",
+      "dev": true,
+      "dependencies": {
+        "get-intrinsic": "^1.2.4",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.1"
       },
       "engines": {
         "node": ">= 0.4"
       }
     },
     "node_modules/es-shim-unscopables": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/es-shim-unscopables/-/es-shim-unscopables-1.0.0.tgz",
-      "integrity": "sha512-Jm6GPcCdC30eMLbZ2x8z2WuRwAws3zTBBKuusffYVUrNj/GVSUAZ+xKMaUpfNDR5IbyNA5LJbaecoUVbmUcB1w==",
+      "version": "1.0.2",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/es-shim-unscopables/-/es-shim-unscopables-1.0.2.tgz",
+      "integrity": "sha1-H2lC5x7MeDXtHIqDAG2HcaY6N2M=",
       "dev": true,
       "dependencies": {
-        "has": "^1.0.3"
+        "hasown": "^2.0.0"
       }
     },
     "node_modules/es-to-primitive": {
       "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
-      "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
+      "integrity": "sha1-5VzUyc3BiLzvsDs2bHNjI/xciYo=",
       "dev": true,
       "dependencies": {
         "is-callable": "^1.1.4",
@@ -2560,22 +2554,22 @@
       }
     },
     "node_modules/escalade": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
-      "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
+      "version": "3.1.2",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/escalade/-/escalade-3.1.2.tgz",
+      "integrity": "sha1-VAdumrKepb89jx7WKs/7uIJy3yc=",
       "engines": {
         "node": ">=6"
       }
     },
     "node_modules/escape-html": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
-      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow=="
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg="
     },
     "node_modules/escape-string-regexp": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
-      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha1-FLqDpdNz49MR5a/KKc9b+tllvzQ=",
       "dev": true,
       "engines": {
         "node": ">=10"
@@ -2585,18 +2579,19 @@
       }
     },
     "node_modules/eslint": {
-      "version": "8.51.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.51.0.tgz",
-      "integrity": "sha512-2WuxRZBrlwnXi+/vFSJyjMqrNjtJqiasMzehF0shoLaW7DzS3/9Yvrmq5JiT66+pNjiX4UBnLDiKHcWAr/OInA==",
+      "version": "8.57.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/eslint/-/eslint-8.57.0.tgz",
+      "integrity": "sha1-x4am/Q4LaJQar2JFlvuYcIkZVmg=",
       "dev": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
-        "@eslint/eslintrc": "^2.1.2",
-        "@eslint/js": "8.51.0",
-        "@humanwhocodes/config-array": "^0.11.11",
+        "@eslint/eslintrc": "^2.1.4",
+        "@eslint/js": "8.57.0",
+        "@humanwhocodes/config-array": "^0.11.14",
         "@humanwhocodes/module-importer": "^1.0.1",
         "@nodelib/fs.walk": "^1.2.8",
+        "@ungap/structured-clone": "^1.2.0",
         "ajv": "^6.12.4",
         "chalk": "^4.0.0",
         "cross-spawn": "^7.0.2",
@@ -2640,8 +2635,8 @@
     },
     "node_modules/eslint-config-airbnb-base": {
       "version": "15.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-airbnb-base/-/eslint-config-airbnb-base-15.0.0.tgz",
-      "integrity": "sha512-xaX3z4ZZIcFLvh2oUNvcX5oEofXda7giYmuplVxoOg5A7EXJMrUyqRgR+mhDhPK8LZ4PttFOBvCYDbX3sUoUig==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/eslint-config-airbnb-base/-/eslint-config-airbnb-base-15.0.0.tgz",
+      "integrity": "sha1-awmt2QrHnC+NcjolgOB/OSWv0jY=",
       "dev": true,
       "dependencies": {
         "confusing-browser-globals": "^1.0.10",
@@ -2659,8 +2654,8 @@
     },
     "node_modules/eslint-import-resolver-node": {
       "version": "0.3.9",
-      "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.9.tgz",
-      "integrity": "sha512-WFj2isz22JahUv+B788TlO3N6zL3nNJGU8CcZbPZvVEkBPaJdCV4vy5wyghty5ROFbCRnm132v8BScu5/1BQ8g==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.9.tgz",
+      "integrity": "sha1-1OqsUrii58PNGQPrAPfgUzVhGKw=",
       "dev": true,
       "dependencies": {
         "debug": "^3.2.7",
@@ -2670,8 +2665,8 @@
     },
     "node_modules/eslint-import-resolver-node/node_modules/debug": {
       "version": "3.2.7",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
-      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/debug/-/debug-3.2.7.tgz",
+      "integrity": "sha1-clgLfpFF+zm2Z2+cXl+xALk0F5o=",
       "dev": true,
       "dependencies": {
         "ms": "^2.1.1"
@@ -2679,14 +2674,14 @@
     },
     "node_modules/eslint-import-resolver-node/node_modules/ms": {
       "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha1-V0yBOM4dK1hh8LRFedut1gxmFbI=",
       "dev": true
     },
     "node_modules/eslint-module-utils": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.8.0.tgz",
-      "integrity": "sha512-aWajIYfsqCKRDgUfjEXNN/JlrzauMuSEy5sbd7WXbtW3EH6A6MpwEh42c7qD+MqQo9QMJ6fWLAeIJynx0g6OAw==",
+      "version": "2.8.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/eslint-module-utils/-/eslint-module-utils-2.8.1.tgz",
+      "integrity": "sha1-UvJAQwDDvTPe7OnXNy+zN8wdfDQ=",
       "dev": true,
       "dependencies": {
         "debug": "^3.2.7"
@@ -2702,8 +2697,8 @@
     },
     "node_modules/eslint-module-utils/node_modules/debug": {
       "version": "3.2.7",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
-      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/debug/-/debug-3.2.7.tgz",
+      "integrity": "sha1-clgLfpFF+zm2Z2+cXl+xALk0F5o=",
       "dev": true,
       "dependencies": {
         "ms": "^2.1.1"
@@ -2711,33 +2706,33 @@
     },
     "node_modules/eslint-module-utils/node_modules/ms": {
       "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha1-V0yBOM4dK1hh8LRFedut1gxmFbI=",
       "dev": true
     },
     "node_modules/eslint-plugin-import": {
-      "version": "2.28.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.28.1.tgz",
-      "integrity": "sha512-9I9hFlITvOV55alzoKBI+K9q74kv0iKMeY6av5+umsNwayt59fz692daGyjR+oStBQgx6nwR9rXldDev3Clw+A==",
+      "version": "2.29.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/eslint-plugin-import/-/eslint-plugin-import-2.29.1.tgz",
+      "integrity": "sha1-1Fs3te9ZAdY5wVJw101G0WEVBkM=",
       "dev": true,
       "dependencies": {
-        "array-includes": "^3.1.6",
-        "array.prototype.findlastindex": "^1.2.2",
-        "array.prototype.flat": "^1.3.1",
-        "array.prototype.flatmap": "^1.3.1",
+        "array-includes": "^3.1.7",
+        "array.prototype.findlastindex": "^1.2.3",
+        "array.prototype.flat": "^1.3.2",
+        "array.prototype.flatmap": "^1.3.2",
         "debug": "^3.2.7",
         "doctrine": "^2.1.0",
-        "eslint-import-resolver-node": "^0.3.7",
+        "eslint-import-resolver-node": "^0.3.9",
         "eslint-module-utils": "^2.8.0",
-        "has": "^1.0.3",
-        "is-core-module": "^2.13.0",
+        "hasown": "^2.0.0",
+        "is-core-module": "^2.13.1",
         "is-glob": "^4.0.3",
         "minimatch": "^3.1.2",
-        "object.fromentries": "^2.0.6",
-        "object.groupby": "^1.0.0",
-        "object.values": "^1.1.6",
+        "object.fromentries": "^2.0.7",
+        "object.groupby": "^1.0.1",
+        "object.values": "^1.1.7",
         "semver": "^6.3.1",
-        "tsconfig-paths": "^3.14.2"
+        "tsconfig-paths": "^3.15.0"
       },
       "engines": {
         "node": ">=4"
@@ -2748,8 +2743,8 @@
     },
     "node_modules/eslint-plugin-import/node_modules/debug": {
       "version": "3.2.7",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
-      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/debug/-/debug-3.2.7.tgz",
+      "integrity": "sha1-clgLfpFF+zm2Z2+cXl+xALk0F5o=",
       "dev": true,
       "dependencies": {
         "ms": "^2.1.1"
@@ -2757,8 +2752,8 @@
     },
     "node_modules/eslint-plugin-import/node_modules/doctrine": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
-      "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/doctrine/-/doctrine-2.1.0.tgz",
+      "integrity": "sha1-XNAfwQFiG0LEzX9dGmYkNxbT850=",
       "dev": true,
       "dependencies": {
         "esutils": "^2.0.2"
@@ -2769,14 +2764,14 @@
     },
     "node_modules/eslint-plugin-import/node_modules/ms": {
       "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha1-V0yBOM4dK1hh8LRFedut1gxmFbI=",
       "dev": true
     },
     "node_modules/eslint-scope": {
       "version": "7.2.2",
-      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.2.2.tgz",
-      "integrity": "sha512-dOt21O7lTMhDM+X9mB4GX+DZrZtCUJPL/wlcTqxyrx5IvO0IYtILdtrQGQp+8n5S0gwSVmOf9NQrjMOgfQZlIg==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/eslint-scope/-/eslint-scope-7.2.2.tgz",
+      "integrity": "sha1-3rT5JWM5DzIAaJSvYqItuhxGQj8=",
       "dev": true,
       "dependencies": {
         "esrecurse": "^4.3.0",
@@ -2791,8 +2786,8 @@
     },
     "node_modules/eslint-visitor-keys": {
       "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
-      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha1-DNcv6FUOPC6uFWqWpN3c0cisWAA=",
       "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -2803,8 +2798,8 @@
     },
     "node_modules/eslint/node_modules/debug": {
       "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha1-Exn2V5NX8jONMzfSzdSRS7XcyGU=",
       "dev": true,
       "dependencies": {
         "ms": "2.1.2"
@@ -2820,14 +2815,14 @@
     },
     "node_modules/eslint/node_modules/ms": {
       "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha1-0J0fNXtEP0kzgqjrPM0YOHKuYAk=",
       "dev": true
     },
     "node_modules/espree": {
       "version": "9.6.1",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-9.6.1.tgz",
-      "integrity": "sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/espree/-/espree-9.6.1.tgz",
+      "integrity": "sha1-oqF7jkNGkKVDLy+AGM5x0zGkjG8=",
       "dev": true,
       "dependencies": {
         "acorn": "^8.9.0",
@@ -2843,8 +2838,8 @@
     },
     "node_modules/esprima": {
       "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha1-E7BM2z5sXRnfkatph6hpVhmwqnE=",
       "dev": true,
       "bin": {
         "esparse": "bin/esparse.js",
@@ -2856,8 +2851,8 @@
     },
     "node_modules/esquery": {
       "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.5.0.tgz",
-      "integrity": "sha512-YQLXUplAwJgCydQ78IMJywZCceoqk1oH01OERdSAJc/7U2AylwjhSCLDEtqwg811idIS/9fIU5GjG73IgjKMVg==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/esquery/-/esquery-1.5.0.tgz",
+      "integrity": "sha1-bOF3ON6Fd2lO3XNhxXGCrIyw2ws=",
       "dev": true,
       "dependencies": {
         "estraverse": "^5.1.0"
@@ -2868,8 +2863,8 @@
     },
     "node_modules/esrecurse": {
       "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
-      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/esrecurse/-/esrecurse-4.3.0.tgz",
+      "integrity": "sha1-eteWTWeauyi+5yzsY3WLHF0smSE=",
       "dev": true,
       "dependencies": {
         "estraverse": "^5.2.0"
@@ -2880,8 +2875,8 @@
     },
     "node_modules/estraverse": {
       "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
-      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha1-LupSkHAvJquP5TcDcP+GyWXSESM=",
       "dev": true,
       "engines": {
         "node": ">=4.0"
@@ -2889,8 +2884,8 @@
     },
     "node_modules/esutils": {
       "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
-      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha1-dNLrTeC42hKTcRkQ1Qd1ubcQ72Q=",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -2898,16 +2893,16 @@
     },
     "node_modules/etag": {
       "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
-      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=",
       "engines": {
         "node": ">= 0.6"
       }
     },
     "node_modules/execa": {
       "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
-      "integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/execa/-/execa-5.1.1.tgz",
+      "integrity": "sha1-+ArZy/Qpj3vR1MlVXCHpN0HEEd0=",
       "dev": true,
       "dependencies": {
         "cross-spawn": "^7.0.3",
@@ -2929,8 +2924,8 @@
     },
     "node_modules/exit": {
       "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
-      "integrity": "sha512-Zk/eNKV2zbjpKzrsQ+n1G6poVbErQxJ0LBOJXaKZ1EViLzH+hrLu9cdXI4zw9dBQJslwBEpbQ2P1oS7nDxs6jQ==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/exit/-/exit-0.1.2.tgz",
+      "integrity": "sha1-BjJjj42HfMghB9MKD/8aF8uhzQw=",
       "dev": true,
       "engines": {
         "node": ">= 0.8.0"
@@ -2938,8 +2933,8 @@
     },
     "node_modules/expect": {
       "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/expect/-/expect-29.7.0.tgz",
-      "integrity": "sha512-2Zks0hf1VLFYI1kbh0I5jP3KHHyCHpkfyHBzsSXRFgl/Bg9mWYfMW8oD+PdMPlEwy5HNsR9JutYy6pMeOh61nw==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/expect/-/expect-29.7.0.tgz",
+      "integrity": "sha1-V4h0WQ3LMhRRQITAgRXYruYeEbw=",
       "dev": true,
       "dependencies": {
         "@jest/expect-utils": "^29.7.0",
@@ -2995,26 +2990,26 @@
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha1-On1WtVnWy8PrUSMlJE5hmmXGxSU=",
       "dev": true
     },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
-      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha1-h0v2nG9ATCtdmcSBNBOZ/VWJJjM=",
       "dev": true
     },
     "node_modules/fast-levenshtein": {
       "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
-      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
     },
     "node_modules/fastq": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.15.0.tgz",
-      "integrity": "sha512-wBrocU2LCXXa+lWBt8RoIRD89Fi8OdABODa/kEnyeyjS5aZO5/GNvI5sEINADqP/h8M29UHTHUb53sUu5Ihqdw==",
+      "version": "1.17.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/fastq/-/fastq-1.17.1.tgz",
+      "integrity": "sha1-KlI/B6TnsegaQrkbi/IlQQd1O0c=",
       "dev": true,
       "dependencies": {
         "reusify": "^1.0.4"
@@ -3022,8 +3017,8 @@
     },
     "node_modules/fb-watchman": {
       "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-2.0.2.tgz",
-      "integrity": "sha512-p5161BqbuCaSnB8jIbzQHOlpgsPmK5rJVDfDKO91Axs5NC1uu3HRQm6wt9cd9/+GtQQIO53JdGXXoyDpTAsgYA==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/fb-watchman/-/fb-watchman-2.0.2.tgz",
+      "integrity": "sha1-6VJO5rXHfp5QAa8PhfOtu4YjJVw=",
       "dev": true,
       "dependencies": {
         "bser": "2.1.1"
@@ -3031,8 +3026,8 @@
     },
     "node_modules/file-entry-cache": {
       "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
-      "integrity": "sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
+      "integrity": "sha1-IRst2WWcsDlLBz5zI6w8kz1SICc=",
       "dev": true,
       "dependencies": {
         "flat-cache": "^3.0.4"
@@ -3042,9 +3037,9 @@
       }
     },
     "node_modules/fill-range": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "version": "7.1.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha1-RCZdPKwH4+p9wkdRY4BkN1SgUpI=",
       "dev": true,
       "dependencies": {
         "to-regex-range": "^5.0.1"
@@ -3055,8 +3050,8 @@
     },
     "node_modules/finalhandler": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.2.0.tgz",
-      "integrity": "sha512-5uXcUVftlQMFnWC9qu/svkWv3GTd2PfUhK/3PLkYNAe7FbqJMt3515HaxE6eRL74GdsriiwujiawdaB1BpEISg==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/finalhandler/-/finalhandler-1.2.0.tgz",
+      "integrity": "sha1-fSP+VzGyB7RkDk/NAK7B+SB6ezI=",
       "dependencies": {
         "debug": "2.6.9",
         "encodeurl": "~1.0.2",
@@ -3072,8 +3067,8 @@
     },
     "node_modules/find-up": {
       "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
-      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha1-TJKBnstwg1YeT0okCoa+UZj1Nvw=",
       "dev": true,
       "dependencies": {
         "locate-path": "^6.0.0",
@@ -3087,9 +3082,9 @@
       }
     },
     "node_modules/flat-cache": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.1.1.tgz",
-      "integrity": "sha512-/qM2b3LUIaIgviBQovTLvijfyOQXPtSRnRK26ksj2J7rzPIecePUIpJsZ4T02Qg+xiAEKIs5K8dsHEd+VaKa/Q==",
+      "version": "3.2.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/flat-cache/-/flat-cache-3.2.0.tgz",
+      "integrity": "sha1-LAwtUEDJmxYydxqdEFclwBFTY+4=",
       "dev": true,
       "dependencies": {
         "flatted": "^3.2.9",
@@ -3097,38 +3092,19 @@
         "rimraf": "^3.0.2"
       },
       "engines": {
-        "node": ">=12.0.0"
+        "node": "^10.12.0 || >=12.0.0"
       }
     },
     "node_modules/flatted": {
-      "version": "3.2.9",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.9.tgz",
-      "integrity": "sha512-36yxDn5H7OFZQla0/jFJmbIKTdZAQHngCedGxiMmpNfEZM0sdEeT+WczLQrjK6D7o2aiyLYDnkw0R3JK0Qv1RQ==",
+      "version": "3.3.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/flatted/-/flatted-3.3.1.tgz",
+      "integrity": "sha1-IdtHBymmc01JlwAvQ5yzCJh/Vno=",
       "dev": true
-    },
-    "node_modules/follow-redirects": {
-      "version": "1.15.6",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/follow-redirects/-/follow-redirects-1.15.6.tgz",
-      "integrity": "sha1-f4FcDNpCScdP8J6V75fCO1/QOZs=",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://github.com/sponsors/RubenVerborgh"
-        }
-      ],
-      "engines": {
-        "node": ">=4.0"
-      },
-      "peerDependenciesMeta": {
-        "debug": {
-          "optional": true
-        }
-      }
     },
     "node_modules/for-each": {
       "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
-      "integrity": "sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/for-each/-/for-each-0.3.3.tgz",
+      "integrity": "sha1-abRH6IoKXTLD5whPPxcQA0shN24=",
       "dev": true,
       "dependencies": {
         "is-callable": "^1.1.3"
@@ -3136,31 +3112,30 @@
     },
     "node_modules/forwarded": {
       "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
-      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha1-ImmTZCiq1MFcfr6XeahL8LKoGBE=",
       "engines": {
         "node": ">= 0.6"
       }
     },
     "node_modules/fresh": {
       "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
-      "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/fresh/-/fresh-0.5.2.tgz",
+      "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac=",
       "engines": {
         "node": ">= 0.6"
       }
     },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw=="
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
     },
     "node_modules/fsevents": {
       "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
-      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha1-ysZAd4XQNnWipeGlMFxpezR9kNY=",
       "dev": true,
-      "hasInstallScript": true,
       "optional": true,
       "os": [
         "darwin"
@@ -3171,16 +3146,16 @@
     },
     "node_modules/function-bind": {
       "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
-      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha1-LALYZNl/PqbIgwxGTL0Rq26rehw=",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/function.prototype.name": {
       "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.6.tgz",
-      "integrity": "sha512-Z5kx79swU5P27WEayXM1tBi5Ze/lbIyiNgU3qyXUOf9b2rgXYyF9Dy9Cx+IQv/Lc8WCG6L82zwUPpSS9hGehIg==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/function.prototype.name/-/function.prototype.name-1.1.6.tgz",
+      "integrity": "sha1-zfMVt9kO53pMbuIWw8M2LaB1M/0=",
       "dev": true,
       "dependencies": {
         "call-bind": "^1.0.2",
@@ -3197,8 +3172,8 @@
     },
     "node_modules/functions-have-names": {
       "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz",
-      "integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/functions-have-names/-/functions-have-names-1.2.3.tgz",
+      "integrity": "sha1-BAT+TuK6L2B/Dg7DyAuumUEzuDQ=",
       "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -3206,8 +3181,8 @@
     },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",
-      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
-      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha1-MqbudsPX9S1GsrGuXZP+qFgKJeA=",
       "dev": true,
       "engines": {
         "node": ">=6.9.0"
@@ -3215,21 +3190,25 @@
     },
     "node_modules/get-caller-file": {
       "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
-      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha1-T5RBKoLbMvNuOwuXQfipf+sDH34=",
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
       }
     },
     "node_modules/get-intrinsic": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.1.tgz",
-      "integrity": "sha512-2DcsyfABl+gVHEfCOaTrWgyt+tb6MSEGmKq+kI5HwLbIYgjgmMcV8KQ41uaKz1xxUcn9tJtgFbQUEVcEbd0FYw==",
+      "version": "1.2.4",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/get-intrinsic/-/get-intrinsic-1.2.4.tgz",
+      "integrity": "sha1-44X1pLUifUScPqu60FSU7wq76t0=",
       "dependencies": {
-        "function-bind": "^1.1.1",
-        "has": "^1.0.3",
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2",
         "has-proto": "^1.0.1",
-        "has-symbols": "^1.0.3"
+        "has-symbols": "^1.0.3",
+        "hasown": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -3237,8 +3216,8 @@
     },
     "node_modules/get-package-type": {
       "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/get-package-type/-/get-package-type-0.1.0.tgz",
-      "integrity": "sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/get-package-type/-/get-package-type-0.1.0.tgz",
+      "integrity": "sha1-jeLYA8/0TfO8bEVuZmizbDkm4Ro=",
       "dev": true,
       "engines": {
         "node": ">=8.0.0"
@@ -3246,8 +3225,8 @@
     },
     "node_modules/get-stream": {
       "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
-      "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/get-stream/-/get-stream-6.0.1.tgz",
+      "integrity": "sha1-omLY7vZ6ztV8KFKtYWdSakPL97c=",
       "dev": true,
       "engines": {
         "node": ">=10"
@@ -3257,13 +3236,14 @@
       }
     },
     "node_modules/get-symbol-description": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.0.0.tgz",
-      "integrity": "sha512-2EmdH1YvIQiZpltCNgkuiUnyukzxM/R6NDJX31Ke3BG1Nq5b0S2PhX59UKi9vZpPDQVdqn+1IcaAwnzTT5vCjw==",
+      "version": "1.0.2",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/get-symbol-description/-/get-symbol-description-1.0.2.tgz",
+      "integrity": "sha1-UzdE1aogrKTgecjl2vf9RCAoIfU=",
       "dev": true,
       "dependencies": {
-        "call-bind": "^1.0.2",
-        "get-intrinsic": "^1.1.1"
+        "call-bind": "^1.0.5",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.4"
       },
       "engines": {
         "node": ">= 0.4"
@@ -3274,8 +3254,8 @@
     },
     "node_modules/glob": {
       "version": "7.2.3",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha1-uN8PuAK7+o6JvR2Ti04WV47UTys=",
       "dependencies": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -3293,8 +3273,8 @@
     },
     "node_modules/glob-parent": {
       "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
-      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha1-bSN9mQg5UMeSkPJMdkKj3poo+eM=",
       "dev": true,
       "dependencies": {
         "is-glob": "^4.0.3"
@@ -3304,9 +3284,9 @@
       }
     },
     "node_modules/globals": {
-      "version": "13.23.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-13.23.0.tgz",
-      "integrity": "sha512-XAmF0RjlrjY23MA51q3HltdlGxUpXPvg0GioKiD9X6HD28iMjo2dKC8Vqwm7lne4GNr78+RHTfliktR6ZH09wA==",
+      "version": "13.24.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/globals/-/globals-13.24.0.tgz",
+      "integrity": "sha1-hDKhnXjODB6DOUnDats0VAC7EXE=",
       "dev": true,
       "dependencies": {
         "type-fest": "^0.20.2"
@@ -3319,12 +3299,13 @@
       }
     },
     "node_modules/globalthis": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.3.tgz",
-      "integrity": "sha512-sFdI5LyBiNTHjRd7cGPWapiHWMOXKyuBNX/cWJ3NfzrZQVa8GI/8cofCl74AOVqq9W5kNmguTIzJ/1s2gyI9wA==",
+      "version": "1.0.4",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/globalthis/-/globalthis-1.0.4.tgz",
+      "integrity": "sha1-dDDtOpddl7+1m8zkH1yruvplEjY=",
       "dev": true,
       "dependencies": {
-        "define-properties": "^1.1.3"
+        "define-properties": "^1.2.1",
+        "gopd": "^1.0.1"
       },
       "engines": {
         "node": ">= 0.4"
@@ -3335,9 +3316,8 @@
     },
     "node_modules/gopd": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
-      "integrity": "sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==",
-      "dev": true,
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/gopd/-/gopd-1.0.1.tgz",
+      "integrity": "sha1-Kf923mnax0ibfAkYpXiOVkd8Myw=",
       "dependencies": {
         "get-intrinsic": "^1.1.3"
       },
@@ -3347,28 +3327,20 @@
     },
     "node_modules/graceful-fs": {
       "version": "4.2.11",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
-      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha1-QYPk6L8Iu24Fu7L30uDI9xLKQOM=",
       "dev": true
     },
     "node_modules/graphemer": {
       "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
-      "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/graphemer/-/graphemer-1.4.0.tgz",
+      "integrity": "sha1-+y8dVeDjoYSa7/yQxPoN1ToOZsY=",
       "dev": true
-    },
-    "node_modules/has": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/has/-/has-1.0.4.tgz",
-      "integrity": "sha512-qdSAmqLF6209RFj4VVItywPMbm3vWylknmB3nvNiUIs72xAimcM8nVYxYr7ncvZq5qzk9MKIZR8ijqD/1QuYjQ==",
-      "engines": {
-        "node": ">= 0.4.0"
-      }
     },
     "node_modules/has-bigints": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.2.tgz",
-      "integrity": "sha512-tSvCKtBr9lkF0Ex0aQiP9N+OpV4zi2r/Nee5VkRDbaqv35RLYMzbwQfFSZZH0kR+Rd6302UJZ2p/bJCEoR3VoQ==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/has-bigints/-/has-bigints-1.0.2.tgz",
+      "integrity": "sha1-CHG9Pj1RYm9soJZmaLo11WAtbqo=",
       "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -3376,29 +3348,28 @@
     },
     "node_modules/has-flag": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha1-lEdx/ZyByBJlxNaUGGDaBrtZR5s=",
       "dev": true,
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/has-property-descriptors": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.0.tgz",
-      "integrity": "sha512-62DVLZGoiEBDHQyqG4w9xCuZ7eJEwNmJRWw2VY84Oedb7WFcA27fiEVe8oUQx9hAUJ4ekurquucTGwsyO1XGdQ==",
-      "dev": true,
+      "version": "1.0.2",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+      "integrity": "sha1-lj7X0HHce/XwhMW/vg0bYiJYaFQ=",
       "dependencies": {
-        "get-intrinsic": "^1.1.1"
+        "es-define-property": "^1.0.0"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/has-proto": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.0.1.tgz",
-      "integrity": "sha512-7qE+iP+O+bgF9clE5+UoBFzE65mlBiVj3tKCrlNQ0Ogwm0BjpT/gK4SlLYDMybDh5I3TCTKnPPa0oMG7JDYrhg==",
+      "version": "1.0.3",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/has-proto/-/has-proto-1.0.3.tgz",
+      "integrity": "sha1-sx3f6bDm6ZFFNqarKGQm0CFPd/0=",
       "engines": {
         "node": ">= 0.4"
       },
@@ -3408,8 +3379,8 @@
     },
     "node_modules/has-symbols": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
-      "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/has-symbols/-/has-symbols-1.0.3.tgz",
+      "integrity": "sha1-u3ssQ0klHc6HsSX3vfh0qnyLOfg=",
       "engines": {
         "node": ">= 0.4"
       },
@@ -3418,11 +3389,11 @@
       }
     },
     "node_modules/has-tostringtag": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.0.tgz",
-      "integrity": "sha512-kFjcSNhnlGV1kyoGk7OXKSawH5JOb/LzUc5w9B02hOTO0dfFRjbHQKvg1d6cf3HbeUmtU9VbbV3qzZ2Teh97WQ==",
+      "version": "1.0.2",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha1-LNxC1AvvLltO6rfAGnPFTOerWrw=",
       "dependencies": {
-        "has-symbols": "^1.0.2"
+        "has-symbols": "^1.0.3"
       },
       "engines": {
         "node": ">= 0.4"
@@ -3431,16 +3402,27 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha1-AD6vkb563DcuhOxZ3DclLO24AAM=",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/html-escaper": {
       "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
-      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha1-39YAJ9o2o238viNiYsAKWCJoFFM=",
       "dev": true
     },
     "node_modules/http-errors": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
-      "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/http-errors/-/http-errors-2.0.0.tgz",
+      "integrity": "sha1-t3dKFIbvc892Z6ya4IWMASxXudM=",
       "dependencies": {
         "depd": "2.0.0",
         "inherits": "2.0.4",
@@ -3454,8 +3436,8 @@
     },
     "node_modules/human-signals": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
-      "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/human-signals/-/human-signals-2.1.0.tgz",
+      "integrity": "sha1-3JH8ukLk0G5Kuu0zs+ejwC9RTqA=",
       "dev": true,
       "engines": {
         "node": ">=10.17.0"
@@ -3463,8 +3445,8 @@
     },
     "node_modules/iconv-lite": {
       "version": "0.4.24",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
-      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha1-ICK0sl+93CHS9SSXSkdKr+czkIs=",
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3"
       },
@@ -3473,9 +3455,9 @@
       }
     },
     "node_modules/ignore": {
-      "version": "5.2.4",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.4.tgz",
-      "integrity": "sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ==",
+      "version": "5.3.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/ignore/-/ignore-5.3.1.tgz",
+      "integrity": "sha1-UHPlVM1CxbM7OUN19Ti4WT401O8=",
       "dev": true,
       "engines": {
         "node": ">= 4"
@@ -3483,8 +3465,8 @@
     },
     "node_modules/import-fresh": {
       "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
-      "integrity": "sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/import-fresh/-/import-fresh-3.3.0.tgz",
+      "integrity": "sha1-NxYsJfy566oublPVtNiM4X2eDCs=",
       "dev": true,
       "dependencies": {
         "parent-module": "^1.0.0",
@@ -3499,8 +3481,8 @@
     },
     "node_modules/import-local": {
       "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/import-local/-/import-local-3.1.0.tgz",
-      "integrity": "sha512-ASB07uLtnDs1o6EHjKpX34BKYDSqnFerfTOJL2HvMqF70LnxpjkzDB8J44oT9pu4AMPkQwf8jl6szgvNd2tRIg==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/import-local/-/import-local-3.1.0.tgz",
+      "integrity": "sha1-tEed+KX9RPbNziQHBnVnYGPJXLQ=",
       "dev": true,
       "dependencies": {
         "pkg-dir": "^4.2.0",
@@ -3518,8 +3500,8 @@
     },
     "node_modules/imurmurhash": {
       "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
-      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
       "dev": true,
       "engines": {
         "node": ">=0.8.19"
@@ -3527,8 +3509,8 @@
     },
     "node_modules/inflight": {
       "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "dependencies": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -3536,17 +3518,17 @@
     },
     "node_modules/inherits": {
       "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha1-D6LGT5MpF8NDOg3tVTY6rjdBa3w="
     },
     "node_modules/internal-slot": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.5.tgz",
-      "integrity": "sha512-Y+R5hJrzs52QCG2laLn4udYVnxsfny9CpOhNhUvk/SSSVyF6T27FzRbF0sroPidSu3X8oEAkOn2K804mjpt6UQ==",
+      "version": "1.0.7",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/internal-slot/-/internal-slot-1.0.7.tgz",
+      "integrity": "sha1-wG3Mo+2HQkmIEAewpVI7FyoZCAI=",
       "dev": true,
       "dependencies": {
-        "get-intrinsic": "^1.2.0",
-        "has": "^1.0.3",
+        "es-errors": "^1.3.0",
+        "hasown": "^2.0.0",
         "side-channel": "^1.0.4"
       },
       "engines": {
@@ -3555,21 +3537,23 @@
     },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
-      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha1-v/OFQ+64mEglB5/zoqjmy9RngbM=",
       "engines": {
         "node": ">= 0.10"
       }
     },
     "node_modules/is-array-buffer": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.2.tgz",
-      "integrity": "sha512-y+FyyR/w8vfIRq4eQcM1EYgSTnmHXPqaF+IgzgraytCFq5Xh8lllDVmAZolPJiZttZLeFSINPYMaEJ7/vWUa1w==",
+      "version": "3.0.4",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/is-array-buffer/-/is-array-buffer-3.0.4.tgz",
+      "integrity": "sha1-eh+Ss9Ye3SvGXSTxMFMOqT1/rpg=",
       "dev": true,
       "dependencies": {
         "call-bind": "^1.0.2",
-        "get-intrinsic": "^1.2.0",
-        "is-typed-array": "^1.1.10"
+        "get-intrinsic": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -3577,14 +3561,14 @@
     },
     "node_modules/is-arrayish": {
       "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-      "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
       "dev": true
     },
     "node_modules/is-bigint": {
       "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.0.4.tgz",
-      "integrity": "sha512-zB9CruMamjym81i2JZ3UMn54PKGsQzsJeo6xvN3HJJ4CAsQNB6iRutp2To77OfCNuoxspsIhzaPoO1zyCEhFOg==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/is-bigint/-/is-bigint-1.0.4.tgz",
+      "integrity": "sha1-CBR6GHW8KzIAXUHM2Ckd/8ZpHfM=",
       "dev": true,
       "dependencies": {
         "has-bigints": "^1.0.1"
@@ -3595,8 +3579,8 @@
     },
     "node_modules/is-boolean-object": {
       "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.1.2.tgz",
-      "integrity": "sha512-gDYaKHJmnj4aWxyj6YHyXVpdQawtVLHU5cb+eztPGczf6cjuTdwve5ZIEfgXqH4e57An1D1AKf8CZ3kYrQRqYA==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/is-boolean-object/-/is-boolean-object-1.1.2.tgz",
+      "integrity": "sha1-XG3CACRt2TIa5LiFoRS7H3X2Nxk=",
       "dev": true,
       "dependencies": {
         "call-bind": "^1.0.2",
@@ -3611,8 +3595,8 @@
     },
     "node_modules/is-callable": {
       "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
-      "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/is-callable/-/is-callable-1.2.7.tgz",
+      "integrity": "sha1-O8KoXqdC2eNiBdys3XLKH9xRsFU=",
       "dev": true,
       "engines": {
         "node": ">= 0.4"
@@ -3622,11 +3606,26 @@
       }
     },
     "node_modules/is-core-module": {
-      "version": "2.13.0",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.13.0.tgz",
-      "integrity": "sha512-Z7dk6Qo8pOCp3l4tsX2C5ZVas4V+UxwQodwZhLopL91TX8UyyHEXafPcyoeeWuLrwzHcr3igO78wNLwHJHsMCQ==",
+      "version": "2.13.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/is-core-module/-/is-core-module-2.13.1.tgz",
+      "integrity": "sha1-rQ11Msb+qdoevcgnQtdFJcYnM4Q=",
       "dependencies": {
-        "has": "^1.0.3"
+        "hasown": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-data-view": {
+      "version": "1.0.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/is-data-view/-/is-data-view-1.0.1.tgz",
+      "integrity": "sha1-S006URtw89wm1CwDypylFdhHdZ8=",
+      "dev": true,
+      "dependencies": {
+        "is-typed-array": "^1.1.13"
+      },
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -3634,8 +3633,8 @@
     },
     "node_modules/is-date-object": {
       "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.5.tgz",
-      "integrity": "sha512-9YQaSxsAiSwcvS33MBk3wTCVnWK+HhF8VZR2jRxehM16QcVOdHqPn4VPHmRK4lSr38n9JriurInLcP90xsYNfQ==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/is-date-object/-/is-date-object-1.0.5.tgz",
+      "integrity": "sha1-CEHVU25yTCVZe/bqYuG9OCmN8x8=",
       "dev": true,
       "dependencies": {
         "has-tostringtag": "^1.0.0"
@@ -3649,8 +3648,8 @@
     },
     "node_modules/is-expression": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/is-expression/-/is-expression-4.0.0.tgz",
-      "integrity": "sha512-zMIXX63sxzG3XrkHkrAPvm/OVZVSCPNkwMHU8oTX7/U3AL78I0QXCEICXUM13BIa8TYGZ68PiTKfQz3yaTNr4A==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/is-expression/-/is-expression-4.0.0.tgz",
+      "integrity": "sha1-wzFVliq/IdCv0lUlFNZ9LsFv0qs=",
       "dependencies": {
         "acorn": "^7.1.1",
         "object-assign": "^4.1.1"
@@ -3658,8 +3657,8 @@
     },
     "node_modules/is-expression/node_modules/acorn": {
       "version": "7.4.1",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
-      "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/acorn/-/acorn-7.4.1.tgz",
+      "integrity": "sha1-/q7SVZc9LndVW4PbwIhRpsY1IPo=",
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3669,8 +3668,8 @@
     },
     "node_modules/is-extglob": {
       "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
-      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -3678,16 +3677,16 @@
     },
     "node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha1-8Rb4Bk/pCz94RKOJl8C3UFEmnx0=",
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/is-generator-fn": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/is-generator-fn/-/is-generator-fn-2.1.0.tgz",
-      "integrity": "sha512-cTIB4yPYL/Grw0EaSzASzg6bBy9gqCofvWN8okThAYIxKJZC+udlRAmGbM0XLeniEJSs8uEgHPGuHSe1XsOLSQ==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/is-generator-fn/-/is-generator-fn-2.1.0.tgz",
+      "integrity": "sha1-fRQK3DiarzARqPKipM+m+q3/sRg=",
       "dev": true,
       "engines": {
         "node": ">=6"
@@ -3695,8 +3694,8 @@
     },
     "node_modules/is-glob": {
       "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
-      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha1-ZPYeQsu7LuwgcanawLKLoeZdUIQ=",
       "dev": true,
       "dependencies": {
         "is-extglob": "^2.1.1"
@@ -3706,9 +3705,9 @@
       }
     },
     "node_modules/is-negative-zero": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.2.tgz",
-      "integrity": "sha512-dqJvarLawXsFbNDeJW7zAz8ItJ9cd28YufuuFzh0G8pNHjJMnY08Dv7sYX2uF5UpQOwieAeOExEYAWWfu7ZZUA==",
+      "version": "2.0.3",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/is-negative-zero/-/is-negative-zero-2.0.3.tgz",
+      "integrity": "sha1-ztkDoCespjgbd3pXQwadc3akl0c=",
       "dev": true,
       "engines": {
         "node": ">= 0.4"
@@ -3719,8 +3718,8 @@
     },
     "node_modules/is-number": {
       "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
-      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha1-dTU0W4lnNNX4DE0GxQlVUnoU8Ss=",
       "dev": true,
       "engines": {
         "node": ">=0.12.0"
@@ -3728,8 +3727,8 @@
     },
     "node_modules/is-number-object": {
       "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.7.tgz",
-      "integrity": "sha512-k1U0IRzLMo7ZlYIfzRu23Oh6MiIFasgpb9X76eqfFZAqwH44UI4KTBvBYIZ1dSL9ZzChTB9ShHfLkR4pdW5krQ==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/is-number-object/-/is-number-object-1.0.7.tgz",
+      "integrity": "sha1-WdUK2kxFJReE6ZBPUkbHQvB6Qvw=",
       "dev": true,
       "dependencies": {
         "has-tostringtag": "^1.0.0"
@@ -3743,8 +3742,8 @@
     },
     "node_modules/is-path-inside": {
       "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
-      "integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/is-path-inside/-/is-path-inside-3.0.3.tgz",
+      "integrity": "sha1-0jE2LlOgf/Kw4Op/7QSRYf/RYoM=",
       "dev": true,
       "engines": {
         "node": ">=8"
@@ -3752,13 +3751,13 @@
     },
     "node_modules/is-promise": {
       "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.2.2.tgz",
-      "integrity": "sha512-+lP4/6lKUBfQjZ2pdxThZvLUAafmZb8OAxFb8XXtiQmS35INgr85hdOGoEs124ez1FCnZJt6jau/T+alh58QFQ=="
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/is-promise/-/is-promise-2.2.2.tgz",
+      "integrity": "sha1-OauVnMv5p3TPB597QMeib3YxNfE="
     },
     "node_modules/is-regex": {
       "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.4.tgz",
-      "integrity": "sha512-kvRdxDsxZjhzUX07ZnLydzS1TU/TJlTUHHY4YLL87e37oUA49DfkLqgy+VjFocowy29cKvcSiu+kIv728jTTVg==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/is-regex/-/is-regex-1.1.4.tgz",
+      "integrity": "sha1-7vVmPNWfpMCuM5UFMj32hUuxWVg=",
       "dependencies": {
         "call-bind": "^1.0.2",
         "has-tostringtag": "^1.0.0"
@@ -3771,12 +3770,15 @@
       }
     },
     "node_modules/is-shared-array-buffer": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.2.tgz",
-      "integrity": "sha512-sqN2UDu1/0y6uvXyStCOzyhAjCSlHceFoMKJW8W9EU9cvic/QdsZ0kEU93HEy3IUEFZIiH/3w+AH/UQbPHNdhA==",
+      "version": "1.0.3",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/is-shared-array-buffer/-/is-shared-array-buffer-1.0.3.tgz",
+      "integrity": "sha1-Ejfxy6BZzbYkMdN43MN9loAYFog=",
       "dev": true,
       "dependencies": {
-        "call-bind": "^1.0.2"
+        "call-bind": "^1.0.7"
+      },
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -3784,8 +3786,8 @@
     },
     "node_modules/is-stream": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
-      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha1-+sHj1TuXrVqdCunO8jifWBClwHc=",
       "dev": true,
       "engines": {
         "node": ">=8"
@@ -3796,8 +3798,8 @@
     },
     "node_modules/is-string": {
       "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.7.tgz",
-      "integrity": "sha512-tE2UXzivje6ofPW7l23cjDOMa09gb7xlAqG6jG5ej6uPV32TlWP3NKPigtaGeHNu9fohccRYvIiZMfOOnOYUtg==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/is-string/-/is-string-1.0.7.tgz",
+      "integrity": "sha1-DdEr8gBvJVu1j2lREO/3SR7rwP0=",
       "dev": true,
       "dependencies": {
         "has-tostringtag": "^1.0.0"
@@ -3811,8 +3813,8 @@
     },
     "node_modules/is-symbol": {
       "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.4.tgz",
-      "integrity": "sha512-C/CPBqKWnvdcxqIARxyOh4v1UUEOCHpgDa0WYgpKDFMszcrPcffg5uhwSgPCLD2WWxmq6isisz87tzT01tuGhg==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/is-symbol/-/is-symbol-1.0.4.tgz",
+      "integrity": "sha1-ptrJO2NbBjymhyI23oiRClevE5w=",
       "dev": true,
       "dependencies": {
         "has-symbols": "^1.0.2"
@@ -3825,12 +3827,12 @@
       }
     },
     "node_modules/is-typed-array": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.12.tgz",
-      "integrity": "sha512-Z14TF2JNG8Lss5/HMqt0//T9JeHXttXy5pH/DBU4vi98ozO2btxzq9MwYDZYnKwU8nRsz/+GVFVRDq3DkVuSPg==",
+      "version": "1.1.13",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/is-typed-array/-/is-typed-array-1.1.13.tgz",
+      "integrity": "sha1-1sXKVt9iM0lZMi19fdHMpQ3r4ik=",
       "dev": true,
       "dependencies": {
-        "which-typed-array": "^1.1.11"
+        "which-typed-array": "^1.1.14"
       },
       "engines": {
         "node": ">= 0.4"
@@ -3841,8 +3843,8 @@
     },
     "node_modules/is-weakref": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.0.2.tgz",
-      "integrity": "sha512-qctsuLZmIQ0+vSSMfoVvyFe2+GSEvnmZ2ezTup1SBse9+twCCeial6EEi3Nc2KFcf6+qz2FBPnjXsk8xhKSaPQ==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/is-weakref/-/is-weakref-1.0.2.tgz",
+      "integrity": "sha1-lSnzg6kzggXol2XgOS78LxAPBvI=",
       "dev": true,
       "dependencies": {
         "call-bind": "^1.0.2"
@@ -3853,34 +3855,34 @@
     },
     "node_modules/isarray": {
       "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
-      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/isarray/-/isarray-2.0.5.tgz",
+      "integrity": "sha1-ivHkwSISRMxiRZ+vOJQNTmRKVyM=",
       "dev": true
     },
     "node_modules/isexe": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
       "dev": true
     },
     "node_modules/istanbul-lib-coverage": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.0.tgz",
-      "integrity": "sha512-eOeJ5BHCmHYvQK7xt9GkdHuzuCGS1Y6g9Gvnx3Ym33fz/HpLRYxiS0wHNr+m/MBC8B647Xt608vCDEvhl9c6Mw==",
+      "version": "3.2.2",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha1-LRZsSwZE1Do58Ev2wu3R5YXzF1Y=",
       "dev": true,
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/istanbul-lib-instrument": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-6.0.1.tgz",
-      "integrity": "sha512-EAMEJBsYuyyztxMxW3g7ugGPkrZsV57v0Hmv3mm1uQsmB+QnZuepg731CRaIgeUVSdmsTngOkSnauNF8p7FIhA==",
+      "version": "6.0.2",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/istanbul-lib-instrument/-/istanbul-lib-instrument-6.0.2.tgz",
+      "integrity": "sha1-kWVZNs9zgOTkczgwgeOEeLaZk7E=",
       "dev": true,
       "dependencies": {
-        "@babel/core": "^7.12.3",
-        "@babel/parser": "^7.14.7",
-        "@istanbuljs/schema": "^0.1.2",
+        "@babel/core": "^7.23.9",
+        "@babel/parser": "^7.23.9",
+        "@istanbuljs/schema": "^0.1.3",
         "istanbul-lib-coverage": "^3.2.0",
         "semver": "^7.5.4"
       },
@@ -3888,26 +3890,11 @@
         "node": ">=10"
       }
     },
-    "node_modules/istanbul-lib-instrument/node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dev": true,
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/istanbul-lib-instrument/node_modules/semver": {
-      "version": "7.5.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
-      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+      "version": "7.6.2",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/semver/-/semver-7.6.2.tgz",
+      "integrity": "sha1-Hjs0dZ+Jbo8U1hNHMs55iusMbhM=",
       "dev": true,
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -3915,16 +3902,10 @@
         "node": ">=10"
       }
     },
-    "node_modules/istanbul-lib-instrument/node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true
-    },
     "node_modules/istanbul-lib-report": {
       "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
-      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha1-kIMFusmlvRdaxqdEier9D8JEWn0=",
       "dev": true,
       "dependencies": {
         "istanbul-lib-coverage": "^3.0.0",
@@ -3937,8 +3918,8 @@
     },
     "node_modules/istanbul-lib-source-maps": {
       "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-4.0.1.tgz",
-      "integrity": "sha512-n3s8EwkdFIJCG3BPKBYvskgXGoy88ARzvegkitk60NxRdwltLOTaH7CUiMRXvwYorl0Q712iEjcWB+fK/MrWVw==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/istanbul-lib-source-maps/-/istanbul-lib-source-maps-4.0.1.tgz",
+      "integrity": "sha1-iV86cJ/PujTG3lpCk5Ai8+Q1hVE=",
       "dev": true,
       "dependencies": {
         "debug": "^4.1.1",
@@ -3951,8 +3932,8 @@
     },
     "node_modules/istanbul-lib-source-maps/node_modules/debug": {
       "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha1-Exn2V5NX8jONMzfSzdSRS7XcyGU=",
       "dev": true,
       "dependencies": {
         "ms": "2.1.2"
@@ -3968,14 +3949,14 @@
     },
     "node_modules/istanbul-lib-source-maps/node_modules/ms": {
       "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha1-0J0fNXtEP0kzgqjrPM0YOHKuYAk=",
       "dev": true
     },
     "node_modules/istanbul-reports": {
-      "version": "3.1.6",
-      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.1.6.tgz",
-      "integrity": "sha512-TLgnMkKg3iTDsQ9PbPTdpfAK2DzjF9mqUG7RMgcQl8oFjad8ob4laGxv5XV5U9MAfx8D6tSJiUyuAwzLicaxlg==",
+      "version": "3.1.7",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/istanbul-reports/-/istanbul-reports-3.1.7.tgz",
+      "integrity": "sha1-2u0SueHcpRjhXAVuHlN+dBKA+gs=",
       "dev": true,
       "dependencies": {
         "html-escaper": "^2.0.0",
@@ -3987,8 +3968,8 @@
     },
     "node_modules/jest": {
       "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/jest/-/jest-29.7.0.tgz",
-      "integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/jest/-/jest-29.7.0.tgz",
+      "integrity": "sha1-mUZ2/CQXfwiPHF43N/VpcgT/JhM=",
       "dev": true,
       "dependencies": {
         "@jest/core": "^29.7.0",
@@ -4013,8 +3994,8 @@
     },
     "node_modules/jest-changed-files": {
       "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-29.7.0.tgz",
-      "integrity": "sha512-fEArFiwf1BpQ+4bXSprcDc3/x4HSzL4al2tozwVpDFpsxALjLYdyiIK4e5Vz66GQJIbXJ82+35PtysofptNX2w==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/jest-changed-files/-/jest-changed-files-29.7.0.tgz",
+      "integrity": "sha1-HAbQfnfHjhWF0CBCTe3BDW4XrDo=",
       "dev": true,
       "dependencies": {
         "execa": "^5.0.0",
@@ -4027,8 +4008,8 @@
     },
     "node_modules/jest-circus": {
       "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-29.7.0.tgz",
-      "integrity": "sha512-3E1nCMgipcTkCocFwM90XXQab9bS+GMsjdpmPrlelaxwD93Ad8iVEjX/vvHPdLPnFf+L40u+5+iutRdA1N9myw==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/jest-circus/-/jest-circus-29.7.0.tgz",
+      "integrity": "sha1-toF6RfzINdixbVli0MAmRz7jZoo=",
       "dev": true,
       "dependencies": {
         "@jest/environment": "^29.7.0",
@@ -4058,8 +4039,8 @@
     },
     "node_modules/jest-cli": {
       "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-29.7.0.tgz",
-      "integrity": "sha512-OVVobw2IubN/GSYsxETi+gOe7Ka59EFMR/twOU3Jb2GnKKeMGJB5SGUUrEz3SFVmJASUdZUzy83sLNNQ2gZslg==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/jest-cli/-/jest-cli-29.7.0.tgz",
+      "integrity": "sha1-VZLJQHmODK5nfuwWkmTy2DmjeZU=",
       "dev": true,
       "dependencies": {
         "@jest/core": "^29.7.0",
@@ -4091,8 +4072,8 @@
     },
     "node_modules/jest-config": {
       "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-29.7.0.tgz",
-      "integrity": "sha512-uXbpfeQ7R6TZBqI3/TxCU4q4ttk3u0PJeC+E0zbfSoSjq6bJ7buBPxzQPL0ifrkY4DNu4JUdk0ImlBUYi840eQ==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/jest-config/-/jest-config-29.7.0.tgz",
+      "integrity": "sha1-vL2ogG28wBseMWpGu3QIWoSwJF8=",
       "dev": true,
       "dependencies": {
         "@babel/core": "^7.11.6",
@@ -4136,8 +4117,8 @@
     },
     "node_modules/jest-diff": {
       "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-29.7.0.tgz",
-      "integrity": "sha512-LMIgiIrhigmPrs03JHpxUh2yISK3vLFPkAodPeo0+BuF7wA2FoQbkEg1u8gBYBThncu7e1oEDUfIXVuTqLRUjw==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/jest-diff/-/jest-diff-29.7.0.tgz",
+      "integrity": "sha1-AXk0pm67fs9vIF6EaZvhCv1wRYo=",
       "dev": true,
       "dependencies": {
         "chalk": "^4.0.0",
@@ -4151,8 +4132,8 @@
     },
     "node_modules/jest-docblock": {
       "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-29.7.0.tgz",
-      "integrity": "sha512-q617Auw3A612guyaFgsbFeYpNP5t2aoUNLwBUbc/0kD1R4t9ixDbyFTHd1nok4epoVFpr7PmeWHrhvuV3XaJ4g==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/jest-docblock/-/jest-docblock-29.7.0.tgz",
+      "integrity": "sha1-j922rcPNyVXJPiqH9hz9NQ1dEZo=",
       "dev": true,
       "dependencies": {
         "detect-newline": "^3.0.0"
@@ -4163,8 +4144,8 @@
     },
     "node_modules/jest-each": {
       "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/jest-each/-/jest-each-29.7.0.tgz",
-      "integrity": "sha512-gns+Er14+ZrEoC5fhOfYCY1LOHHr0TI+rQUHZS8Ttw2l7gl+80eHc/gFf2Ktkw0+SIACDTeWvpFcv3B04VembQ==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/jest-each/-/jest-each-29.7.0.tgz",
+      "integrity": "sha1-FiqbPyMovdmRvqq/+7dHReVld9E=",
       "dev": true,
       "dependencies": {
         "@jest/types": "^29.6.3",
@@ -4179,8 +4160,8 @@
     },
     "node_modules/jest-environment-node": {
       "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-29.7.0.tgz",
-      "integrity": "sha512-DOSwCRqXirTOyheM+4d5YZOrWcdu0LNZ87ewUoywbcb2XR4wKgqiG8vNeYwhjFMbEkfju7wx2GYH0P2gevGvFw==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/jest-environment-node/-/jest-environment-node-29.7.0.tgz",
+      "integrity": "sha1-C5PhEd2o7BILyDAObR+5V24WQ3Y=",
       "dev": true,
       "dependencies": {
         "@jest/environment": "^29.7.0",
@@ -4196,8 +4177,8 @@
     },
     "node_modules/jest-get-type": {
       "version": "29.6.3",
-      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-29.6.3.tgz",
-      "integrity": "sha512-zrteXnqYxfQh7l5FHyL38jL39di8H8rHoecLH3JNxH3BwOrBsNeabdap5e0I23lD4HHI8W5VFBZqG4Eaq5LNcw==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/jest-get-type/-/jest-get-type-29.6.3.tgz",
+      "integrity": "sha1-NvSZ/c6hl8EEWhJzGcBIFyOQj9E=",
       "dev": true,
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
@@ -4205,8 +4186,8 @@
     },
     "node_modules/jest-haste-map": {
       "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-29.7.0.tgz",
-      "integrity": "sha512-fP8u2pyfqx0K1rGn1R9pyE0/KTn+G7PxktWidOBTqFPLYX0b9ksaMFkhK5vrS3DVun09pckLdlx90QthlW7AmA==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/jest-haste-map/-/jest-haste-map-29.7.0.tgz",
+      "integrity": "sha1-PCOWUkSC9aBQY3bmyFjDu8wXsQQ=",
       "dev": true,
       "dependencies": {
         "@jest/types": "^29.6.3",
@@ -4230,8 +4211,8 @@
     },
     "node_modules/jest-leak-detector": {
       "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-29.7.0.tgz",
-      "integrity": "sha512-kYA8IJcSYtST2BY9I+SMC32nDpBT3J2NvWJx8+JCuCdl/CR1I4EKUJROiP8XtCcxqgTTBGJNdbB1A8XRKbTetw==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/jest-leak-detector/-/jest-leak-detector-29.7.0.tgz",
+      "integrity": "sha1-W37A2t/f7Ayjg9yaoBbTa16kxyg=",
       "dev": true,
       "dependencies": {
         "jest-get-type": "^29.6.3",
@@ -4243,8 +4224,8 @@
     },
     "node_modules/jest-matcher-utils": {
       "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-29.7.0.tgz",
-      "integrity": "sha512-sBkD+Xi9DtcChsI3L3u0+N0opgPYnCRPtGcQYrgXmR+hmt/fYfWAL0xRXYU8eWOdfuLgBe0YCW3AFtnRLagq/g==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/jest-matcher-utils/-/jest-matcher-utils-29.7.0.tgz",
+      "integrity": "sha1-ro/sef8kn9WSzoDj7kdOg6bETxI=",
       "dev": true,
       "dependencies": {
         "chalk": "^4.0.0",
@@ -4258,8 +4239,8 @@
     },
     "node_modules/jest-message-util": {
       "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-29.7.0.tgz",
-      "integrity": "sha512-GBEV4GRADeP+qtB2+6u61stea8mGcOT4mCtrYISZwfu9/ISHFJ/5zOMXYbpBE9RsS5+Gb63DW4FgmnKJ79Kf6w==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/jest-message-util/-/jest-message-util-29.7.0.tgz",
+      "integrity": "sha1-i8OS4gTpXf51ZKu+cqQE4o5R9/M=",
       "dev": true,
       "dependencies": {
         "@babel/code-frame": "^7.12.13",
@@ -4278,8 +4259,8 @@
     },
     "node_modules/jest-mock": {
       "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-29.7.0.tgz",
-      "integrity": "sha512-ITOMZn+UkYS4ZFh83xYAOzWStloNzJFO2s8DWrE4lhtGD+AorgnbkiKERe4wQVBydIGPx059g6riW5Btp6Llnw==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/jest-mock/-/jest-mock-29.7.0.tgz",
+      "integrity": "sha1-ToNs9g6Zxvz6vp+Z0Bfz/dUKY0c=",
       "dev": true,
       "dependencies": {
         "@jest/types": "^29.6.3",
@@ -4292,8 +4273,8 @@
     },
     "node_modules/jest-pnp-resolver": {
       "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.3.tgz",
-      "integrity": "sha512-+3NpwQEnRoIBtx4fyhblQDPgJI0H1IEIkX7ShLUjPGA7TtUTvI1oiKi3SR4oBR0hQhQR80l4WAe5RrXBwWMA8w==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/jest-pnp-resolver/-/jest-pnp-resolver-1.2.3.tgz",
+      "integrity": "sha1-kwsVRhZNStWTfVVA5xHU041MrS4=",
       "dev": true,
       "engines": {
         "node": ">=6"
@@ -4309,8 +4290,8 @@
     },
     "node_modules/jest-regex-util": {
       "version": "29.6.3",
-      "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-29.6.3.tgz",
-      "integrity": "sha512-KJJBsRCyyLNWCNBOvZyRDnAIfUiRJ8v+hOBQYGn8gDyF3UegwiP4gwRR3/SDa42g1YbVycTidUF3rKjyLFDWbg==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/jest-regex-util/-/jest-regex-util-29.6.3.tgz",
+      "integrity": "sha1-SlVtnHdq9o4cX0gZT00DJ9JOilI=",
       "dev": true,
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
@@ -4318,8 +4299,8 @@
     },
     "node_modules/jest-resolve": {
       "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-29.7.0.tgz",
-      "integrity": "sha512-IOVhZSrg+UvVAshDSDtHyFCCBUl/Q3AAJv8iZ6ZjnZ74xzvwuzLXid9IIIPgTnY62SJjfuupMKZsZQRsCvxEgA==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/jest-resolve/-/jest-resolve-29.7.0.tgz",
+      "integrity": "sha1-ZNaomS3Sb2NasMAeXu9Dmca8vDA=",
       "dev": true,
       "dependencies": {
         "chalk": "^4.0.0",
@@ -4338,8 +4319,8 @@
     },
     "node_modules/jest-resolve-dependencies": {
       "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-29.7.0.tgz",
-      "integrity": "sha512-un0zD/6qxJ+S0et7WxeI3H5XSe9lTBBR7bOHCHXkKR6luG5mwDDlIzVQ0V5cZCuoTgEdcdwzTghYkTWfubi+nA==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/jest-resolve-dependencies/-/jest-resolve-dependencies-29.7.0.tgz",
+      "integrity": "sha1-GwTywJXzf8d2/0CAPckpIbHohCg=",
       "dev": true,
       "dependencies": {
         "jest-regex-util": "^29.6.3",
@@ -4351,8 +4332,8 @@
     },
     "node_modules/jest-runner": {
       "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-29.7.0.tgz",
-      "integrity": "sha512-fsc4N6cPCAahybGBfTRcq5wFR6fpLznMg47sY5aDpsoejOcVYFb07AHuSnR0liMcPTgBsA3ZJL6kFOjPdoNipQ==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/jest-runner/-/jest-runner-29.7.0.tgz",
+      "integrity": "sha1-gJrwctQIpT3P0uhJpMl20xMvcY4=",
       "dev": true,
       "dependencies": {
         "@jest/console": "^29.7.0",
@@ -4383,8 +4364,8 @@
     },
     "node_modules/jest-runtime": {
       "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-29.7.0.tgz",
-      "integrity": "sha512-gUnLjgwdGqW7B4LvOIkbKs9WGbn+QLqRQQ9juC6HndeDiezIwhDP+mhMwHWCEcfQ5RUXa6OPnFF8BJh5xegwwQ==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/jest-runtime/-/jest-runtime-29.7.0.tgz",
+      "integrity": "sha1-7+yzFBz303Z6OgzI98mZBYfT2Bc=",
       "dev": true,
       "dependencies": {
         "@jest/environment": "^29.7.0",
@@ -4416,8 +4397,8 @@
     },
     "node_modules/jest-snapshot": {
       "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-29.7.0.tgz",
-      "integrity": "sha512-Rm0BMWtxBcioHr1/OX5YCP8Uov4riHvKPknOGs804Zg9JGZgmIBkbtlxJC/7Z4msKYVbIJtfU+tKb8xlYNfdkw==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/jest-snapshot/-/jest-snapshot-29.7.0.tgz",
+      "integrity": "sha1-wsV0w/UYZdobsykDZ3imm/iKa+U=",
       "dev": true,
       "dependencies": {
         "@babel/core": "^7.11.6",
@@ -4445,26 +4426,11 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
-    "node_modules/jest-snapshot/node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dev": true,
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/jest-snapshot/node_modules/semver": {
-      "version": "7.5.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
-      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+      "version": "7.6.2",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/semver/-/semver-7.6.2.tgz",
+      "integrity": "sha1-Hjs0dZ+Jbo8U1hNHMs55iusMbhM=",
       "dev": true,
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -4472,16 +4438,10 @@
         "node": ">=10"
       }
     },
-    "node_modules/jest-snapshot/node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true
-    },
     "node_modules/jest-util": {
       "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.7.0.tgz",
-      "integrity": "sha512-z6EbKajIpqGKU56y5KBUgy1dt1ihhQJgWzUlZHArA/+X2ad7Cb5iF+AK1EWVL/Bo7Rz9uurpqw6SiBCefUbCGA==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/jest-util/-/jest-util-29.7.0.tgz",
+      "integrity": "sha1-I8K2K/sivoK0TemAVYAv83EPwLw=",
       "dev": true,
       "dependencies": {
         "@jest/types": "^29.6.3",
@@ -4497,8 +4457,8 @@
     },
     "node_modules/jest-validate": {
       "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-29.7.0.tgz",
-      "integrity": "sha512-ZB7wHqaRGVw/9hST/OuFUReG7M8vKeq0/J2egIGLdvjHCmYqGARhzXmtgi+gVeZ5uXFF219aOc3Ls2yLg27tkw==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/jest-validate/-/jest-validate-29.7.0.tgz",
+      "integrity": "sha1-e/cFURxk2lkdRrFfzkFADVIUfZw=",
       "dev": true,
       "dependencies": {
         "@jest/types": "^29.6.3",
@@ -4514,8 +4474,8 @@
     },
     "node_modules/jest-validate/node_modules/camelcase": {
       "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
-      "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/camelcase/-/camelcase-6.3.0.tgz",
+      "integrity": "sha1-VoW5XrIJrJwMF3Rnd4ychN9Yupo=",
       "dev": true,
       "engines": {
         "node": ">=10"
@@ -4526,8 +4486,8 @@
     },
     "node_modules/jest-watcher": {
       "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-29.7.0.tgz",
-      "integrity": "sha512-49Fg7WXkU3Vl2h6LbLtMQ/HyB6rXSIX7SqvBLQmssRBGN9I0PNvPmAmCWSOY6SOvrjhI/F7/bGAv9RtnsPA03g==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/jest-watcher/-/jest-watcher-29.7.0.tgz",
+      "integrity": "sha1-eBDTDWGcOmIJMiPOa7NZyhsoovI=",
       "dev": true,
       "dependencies": {
         "@jest/test-result": "^29.7.0",
@@ -4545,8 +4505,8 @@
     },
     "node_modules/jest-worker": {
       "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-29.7.0.tgz",
-      "integrity": "sha512-eIz2msL/EzL9UFTFFx7jBTkeZfku0yUAyZZZmJ93H2TYEiroIx2PQjEXcwYtYl8zXCxb+PAmA2hLIt/6ZEkPHw==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/jest-worker/-/jest-worker-29.7.0.tgz",
+      "integrity": "sha1-rK0HOsu663JivVOJ4bz0PhAFjUo=",
       "dev": true,
       "dependencies": {
         "@types/node": "*",
@@ -4560,8 +4520,8 @@
     },
     "node_modules/jest-worker/node_modules/supports-color": {
       "version": "8.1.1",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
-      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/supports-color/-/supports-color-8.1.1.tgz",
+      "integrity": "sha1-zW/BfihQDP9WwbhsCn/UpUpzAFw=",
       "dev": true,
       "dependencies": {
         "has-flag": "^4.0.0"
@@ -4580,14 +4540,14 @@
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha1-GSA/tZmR35jjoocFDUZHzerzJJk=",
       "dev": true
     },
     "node_modules/js-yaml": {
       "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/js-yaml/-/js-yaml-4.1.0.tgz",
+      "integrity": "sha1-wftl+PUBeQHN0slRhkuhhFihBgI=",
       "dev": true,
       "dependencies": {
         "argparse": "^2.0.1"
@@ -4598,8 +4558,8 @@
     },
     "node_modules/jsesc": {
       "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
-      "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/jsesc/-/jsesc-2.5.2.tgz",
+      "integrity": "sha1-gFZNLkg9rPbo7yCWUKZ98/DCg6Q=",
       "dev": true,
       "bin": {
         "jsesc": "bin/jsesc"
@@ -4610,32 +4570,32 @@
     },
     "node_modules/json-buffer": {
       "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
-      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/json-buffer/-/json-buffer-3.0.1.tgz",
+      "integrity": "sha1-kziAKjDTtmBfvgYT4JQAjKjAWhM=",
       "dev": true
     },
     "node_modules/json-parse-even-better-errors": {
       "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
-      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
+      "integrity": "sha1-fEeAWpQxmSjgV3dAXcEuH3pO4C0=",
       "dev": true
     },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha1-afaofZUTq4u4/mO9sJecRI5oRmA=",
       "dev": true
     },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
-      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
       "dev": true
     },
     "node_modules/json5": {
       "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
-      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha1-eM1vGhm9wStz21rQxh79ZsHikoM=",
       "dev": true,
       "bin": {
         "json5": "lib/cli.js"
@@ -4667,8 +4627,8 @@
     },
     "node_modules/jsonwebtoken/node_modules/ms": {
       "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha1-V0yBOM4dK1hh8LRFedut1gxmFbI="
     },
     "node_modules/jsonwebtoken/node_modules/semver": {
       "version": "7.6.2",
@@ -4683,8 +4643,8 @@
     },
     "node_modules/jstransformer": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/jstransformer/-/jstransformer-1.0.0.tgz",
-      "integrity": "sha512-C9YK3Rf8q6VAPDCCU9fnqo3mAfOH6vUGnMcP4AQAYIEpWtfGLpwOTmZ+igtdK5y+VvI2n3CyYSzy4Qh34eq24A==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/jstransformer/-/jstransformer-1.0.0.tgz",
+      "integrity": "sha1-7Yvwkh4vPx7U1cGkT2hwntJHIsM=",
       "dependencies": {
         "is-promise": "^2.0.0",
         "promise": "^7.0.1"
@@ -4692,8 +4652,8 @@
     },
     "node_modules/jwa": {
       "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.1.tgz",
-      "integrity": "sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/jwa/-/jwa-1.4.1.tgz",
+      "integrity": "sha1-dDwymFy56YZVUw1TZBtmyGRbA5o=",
       "dependencies": {
         "buffer-equal-constant-time": "1.0.1",
         "ecdsa-sig-formatter": "1.0.11",
@@ -4702,8 +4662,8 @@
     },
     "node_modules/jws": {
       "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
-      "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/jws/-/jws-3.2.2.tgz",
+      "integrity": "sha1-ABCZ82OUaMlBQADpmZX6UvtHgwQ=",
       "dependencies": {
         "jwa": "^1.4.1",
         "safe-buffer": "^5.0.1"
@@ -4711,8 +4671,8 @@
     },
     "node_modules/keyv": {
       "version": "4.5.4",
-      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
-      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/keyv/-/keyv-4.5.4.tgz",
+      "integrity": "sha1-qHmpnilFL5QkOfKkBeOvizHU3pM=",
       "dev": true,
       "dependencies": {
         "json-buffer": "3.0.1"
@@ -4720,8 +4680,8 @@
     },
     "node_modules/kleur": {
       "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
-      "integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/kleur/-/kleur-3.0.3.tgz",
+      "integrity": "sha1-p5yezIbuHOP6YgbRIWxQHxR/wH4=",
       "dev": true,
       "engines": {
         "node": ">=6"
@@ -4729,8 +4689,8 @@
     },
     "node_modules/leven": {
       "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
-      "integrity": "sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/leven/-/leven-3.1.0.tgz",
+      "integrity": "sha1-d4kd6DQGTMy6gq54QrtrFKE+1/I=",
       "dev": true,
       "engines": {
         "node": ">=6"
@@ -4738,8 +4698,8 @@
     },
     "node_modules/levn": {
       "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
-      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/levn/-/levn-0.4.1.tgz",
+      "integrity": "sha1-rkViwAdHO5MqYgDUAyaN0v/8at4=",
       "dev": true,
       "dependencies": {
         "prelude-ls": "^1.2.1",
@@ -4751,14 +4711,14 @@
     },
     "node_modules/lines-and-columns": {
       "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
-      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
+      "integrity": "sha1-7KKE910pZQeTCdwK2SVauy68FjI=",
       "dev": true
     },
     "node_modules/locate-path": {
       "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
-      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha1-VTIeswn+u8WcSAHZMackUqaB0oY=",
       "dev": true,
       "dependencies": {
         "p-locate": "^5.0.0"
@@ -4772,49 +4732,49 @@
     },
     "node_modules/lodash": {
       "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha1-Z5WRxWTDv/quhFTPCz3zcMPWkRw="
     },
     "node_modules/lodash.includes": {
       "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
-      "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w=="
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "integrity": "sha1-YLuYqHy5I8aMoeUTJUgzFISfVT8="
     },
     "node_modules/lodash.isboolean": {
       "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
-      "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg=="
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "integrity": "sha1-bC4XHbKiV82WgC/UOwGyDV9YcPY="
     },
     "node_modules/lodash.isinteger": {
       "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
-      "integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA=="
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+      "integrity": "sha1-YZwK89A/iwTDH1iChAt3sRzWg0M="
     },
     "node_modules/lodash.isnumber": {
       "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
-      "integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw=="
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+      "integrity": "sha1-POdoEMWSjQM1IwGsKHMX8RwLH/w="
     },
     "node_modules/lodash.isplainobject": {
       "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
-      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA=="
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs="
     },
     "node_modules/lodash.isstring": {
       "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
-      "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw=="
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE="
     },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
-      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
-      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha1-VYqlO0O2YeGSWgr9+japoQhf5Xo=",
       "dev": true
     },
     "node_modules/lodash.once": {
       "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
-      "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg=="
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/lodash.once/-/lodash.once-4.1.1.tgz",
+      "integrity": "sha1-DdOXEhPHxW34gJd9UEyI+0cal6w="
     },
     "node_modules/login.dfe.async-retry": {
       "version": "2.0.3",
@@ -4824,12 +4784,10 @@
       }
     },
     "node_modules/login.dfe.jwt-strategies": {
-      "version": "1.1.0",
-      "resolved": "git+ssh://git@github.com/DFE-Digital/login.dfe.jwt-strategies.git#7e2c363a5acf922e04774c7ff6317e7c2697c7f3",
-      "license": "MIT",
+      "version": "4.1.0",
+      "resolved": "git+ssh://git@github.com/DFE-Digital/login.dfe.jwt-strategies.git#33231d6cdf373cc3c2b78b31762cbcc6143b907d",
       "dependencies": {
-        "adal-node": "^0.2.1",
-        "memory-cache": "^0.2.0"
+        "@azure/msal-node": "^2.6.4"
       }
     },
     "node_modules/login.dfe.kue": {
@@ -4853,8 +4811,8 @@
     },
     "node_modules/lru-cache": {
       "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
-      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha1-HaJ+ZxAnGUdpXa9oSOhH8B2EuSA=",
       "dev": true,
       "dependencies": {
         "yallist": "^3.0.2"
@@ -4862,8 +4820,8 @@
     },
     "node_modules/make-dir": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
-      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha1-w8IwencSd82WODBfkVwprnQbYU4=",
       "dev": true,
       "dependencies": {
         "semver": "^7.5.3"
@@ -4875,26 +4833,11 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/make-dir/node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dev": true,
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/make-dir/node_modules/semver": {
-      "version": "7.5.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
-      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+      "version": "7.6.2",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/semver/-/semver-7.6.2.tgz",
+      "integrity": "sha1-Hjs0dZ+Jbo8U1hNHMs55iusMbhM=",
       "dev": true,
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -4902,16 +4845,10 @@
         "node": ">=10"
       }
     },
-    "node_modules/make-dir/node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true
-    },
     "node_modules/makeerror": {
       "version": "1.0.12",
-      "resolved": "https://registry.npmjs.org/makeerror/-/makeerror-1.0.12.tgz",
-      "integrity": "sha512-JmqCvUhmt43madlpFzG4BQzG2Z3m6tvQDNKdClZnO3VbIudJYmxsT0FNJMeiB2+JTSlTQTSbU8QdesVmwJcmLg==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/makeerror/-/makeerror-1.0.12.tgz",
+      "integrity": "sha1-Pl3SB5qC6BLpg8xmEMSiyw6qgBo=",
       "dev": true,
       "dependencies": {
         "tmpl": "1.0.5"
@@ -4919,43 +4856,38 @@
     },
     "node_modules/media-typer": {
       "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
-      "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/media-typer/-/media-typer-0.3.0.tgz",
+      "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=",
       "engines": {
         "node": ">= 0.6"
       }
     },
-    "node_modules/memory-cache": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/memory-cache/-/memory-cache-0.2.0.tgz",
-      "integrity": "sha512-OcjA+jzjOYzKmKS6IQVALHLVz+rNTMPoJvCztFaZxwG14wtAW7VRZjwTQu06vKCYOxh4jVnik7ya0SXTB0W+xA=="
-    },
     "node_modules/merge-descriptors": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
-      "integrity": "sha512-cCi6g3/Zr1iqQi6ySbseM1Xvooa98N0w31jzUYrXPX2xqObmFGHJ0tQ5u74H3mVh7wLouTseZyYIq39g8cNp1w=="
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
+      "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E="
     },
     "node_modules/merge-stream": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
-      "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/merge-stream/-/merge-stream-2.0.0.tgz",
+      "integrity": "sha1-UoI2KaFN0AyXcPtq1H3GMQ8sH2A=",
       "dev": true
     },
     "node_modules/methods": {
       "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
-      "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/methods/-/methods-1.1.2.tgz",
+      "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4=",
       "engines": {
         "node": ">= 0.6"
       }
     },
     "node_modules/micromatch": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
-      "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
+      "version": "4.0.7",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/micromatch/-/micromatch-4.0.7.tgz",
+      "integrity": "sha1-M+gZDZ/kdKmJVSX1YY7uE21GwuU=",
       "dev": true,
       "dependencies": {
-        "braces": "^3.0.2",
+        "braces": "^3.0.3",
         "picomatch": "^2.3.1"
       },
       "engines": {
@@ -4964,8 +4896,8 @@
     },
     "node_modules/mime": {
       "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
-      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha1-Ms2eXGRVO9WNGaVor0Uqz/BJgbE=",
       "bin": {
         "mime": "cli.js"
       },
@@ -4975,16 +4907,16 @@
     },
     "node_modules/mime-db": {
       "version": "1.52.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
-      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha1-u6vNwChZ9JhzAchW4zh85exDv3A=",
       "engines": {
         "node": ">= 0.6"
       }
     },
     "node_modules/mime-types": {
       "version": "2.1.35",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
-      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha1-OBqHG2KnNEUGYK497uRIE/cNlZo=",
       "dependencies": {
         "mime-db": "1.52.0"
       },
@@ -4994,8 +4926,8 @@
     },
     "node_modules/mimic-fn": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
-      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/mimic-fn/-/mimic-fn-2.1.0.tgz",
+      "integrity": "sha1-ftLCzMyvhNP/y3pptXcR/CCDQBs=",
       "dev": true,
       "engines": {
         "node": ">=6"
@@ -5003,8 +4935,8 @@
     },
     "node_modules/minimatch": {
       "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha1-Gc0ZS/0+Qo8EmnCBfAONiatL41s=",
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -5014,16 +4946,16 @@
     },
     "node_modules/minimist": {
       "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
-      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha1-waRk52kzAuCCoHXO4MBXdBrEdyw=",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/mkdirp": {
       "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
-      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/mkdirp/-/mkdirp-1.0.4.tgz",
+      "integrity": "sha1-PrXtYmInVteaXw4qIh3+utdcL34=",
       "bin": {
         "mkdirp": "bin/cmd.js"
       },
@@ -5033,27 +4965,27 @@
     },
     "node_modules/ms": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
     },
     "node_modules/natural-compare": {
       "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
-      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
       "dev": true
     },
     "node_modules/negotiator": {
       "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
-      "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/negotiator/-/negotiator-0.6.3.tgz",
+      "integrity": "sha1-WOMjpy/twNb5zU0x/kn1FHlZDM0=",
       "engines": {
         "node": ">= 0.6"
       }
     },
     "node_modules/nib": {
       "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/nib/-/nib-1.1.2.tgz",
-      "integrity": "sha512-xBpZ9XU0vLOxp0GBTuUHt6Kcl37ZpC/rXPpKcK4LYOUnSmqp2CXkcNiJxf9bgNZeivYR6bxsaZkNHZ9deEMupQ==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/nib/-/nib-1.1.2.tgz",
+      "integrity": "sha1-amnt5AgblcDe+L4CSkyK4MLLtsc=",
       "dependencies": {
         "stylus": "0.54.5"
       },
@@ -5063,13 +4995,13 @@
     },
     "node_modules/nib/node_modules/css-parse": {
       "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/css-parse/-/css-parse-1.7.0.tgz",
-      "integrity": "sha512-OI38lO4JQQX2GSisTqwiSFxiWNmLajXdW4tCCxAuiwGKjusHALQadSHBSxGlU8lrFp47IkLuU2AfSYz31qpETQ=="
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/css-parse/-/css-parse-1.7.0.tgz",
+      "integrity": "sha1-Mh9s9zeCpv91ERE5D8BeLGV9jJs="
     },
     "node_modules/nib/node_modules/glob": {
       "version": "7.0.6",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.0.6.tgz",
-      "integrity": "sha512-f8c0rE8JiCxpa52kWPAOa3ZaYEnzofDzCQLCn3Vdk0Z5OVLq3BsRFJI4S4ykpeVW6QMGBUkMeUpoEgWnMTnw5Q==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/glob/-/glob-7.0.6.tgz",
+      "integrity": "sha1-IRuvr0nlJbjNkyYNFKsTYVKz9Xo=",
       "dependencies": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -5084,8 +5016,8 @@
     },
     "node_modules/nib/node_modules/mkdirp": {
       "version": "0.5.6",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
-      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/mkdirp/-/mkdirp-0.5.6.tgz",
+      "integrity": "sha1-fe8D0kMtyuS6HWEURcSDlgYiVfY=",
       "dependencies": {
         "minimist": "^1.2.6"
       },
@@ -5095,13 +5027,13 @@
     },
     "node_modules/nib/node_modules/sax": {
       "version": "0.5.8",
-      "resolved": "https://registry.npmjs.org/sax/-/sax-0.5.8.tgz",
-      "integrity": "sha512-c0YL9VcSfcdH3F1Qij9qpYJFpKFKMXNOkLWFssBL3RuF7ZS8oZhllR2rWlCRjDTJsfq3R6wbSsaRU6o0rkEdNw=="
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/sax/-/sax-0.5.8.tgz",
+      "integrity": "sha1-1HLbIo6zMcJQaw6MFVJK25OdEsE="
     },
     "node_modules/nib/node_modules/source-map": {
       "version": "0.1.43",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
-      "integrity": "sha512-VtCvB9SIQhk3aF6h+N85EaqIaBFIAfZ9Cu+NJHHVvc8BbEcnvDcFw6sqQ2dQrT6SlOrZq3tIvyD9+EGq/lJryQ==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/source-map/-/source-map-0.1.43.tgz",
+      "integrity": "sha1-wkvBRspRfBRx9drL4lcbK3+eM0Y=",
       "dependencies": {
         "amdefine": ">=0.0.4"
       },
@@ -5111,8 +5043,8 @@
     },
     "node_modules/nib/node_modules/stylus": {
       "version": "0.54.5",
-      "resolved": "https://registry.npmjs.org/stylus/-/stylus-0.54.5.tgz",
-      "integrity": "sha512-4Yzg9aqLf3f4sDvO3x+Fbp2V634j9ikFGCFokIPYi+7Y4IG/nxAiPUs95MRlo+lPdTsxAs9wCzEclmPccItISA==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/stylus/-/stylus-0.54.5.tgz",
+      "integrity": "sha1-QrlWCTHKcJDOhRWnmLqeaqPW3Hk=",
       "dependencies": {
         "css-parse": "1.7.x",
         "debug": "*",
@@ -5130,34 +5062,34 @@
     },
     "node_modules/node-int64": {
       "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
-      "integrity": "sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/node-int64/-/node-int64-0.4.0.tgz",
+      "integrity": "sha1-h6kGXNs1XTGC2PlM4RGIuCXGijs=",
       "dev": true
     },
     "node_modules/node-redis-script": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/node-redis-script/-/node-redis-script-2.0.1.tgz",
-      "integrity": "sha512-m4CXMTSpS1qsND8Awu20wve+9CTe8XU3Haakt6OT8EtC9wmDUPPtDI8Bm2TkSO4NX+dZhVzX+issU9GXo5PK1A=="
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/node-redis-script/-/node-redis-script-2.0.1.tgz",
+      "integrity": "sha1-qRhOo225BPrGoM4Oe267btEHhPE="
     },
     "node_modules/node-redis-warlock": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/node-redis-warlock/-/node-redis-warlock-1.0.2.tgz",
-      "integrity": "sha512-7o6KeZbVrBWXIGpUR9zAuyw1G5OYem8AP+c3Ud7jSB6HUrBKZW/KOKXVE+NKfRPko9pLbzZxfVE/9Dx+rtzPfg==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/node-redis-warlock/-/node-redis-warlock-1.0.2.tgz",
+      "integrity": "sha1-fCVobWfTVO5gG6lLb90p9ofex2w=",
       "dependencies": {
         "node-redis-script": "^2.0.1",
         "uuid": "^8.3.2"
       }
     },
     "node_modules/node-releases": {
-      "version": "2.0.13",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.13.tgz",
-      "integrity": "sha512-uYr7J37ae/ORWdZeQ1xxMJe3NtdmqMC/JZK+geofDrkLUApKRHPd18/TxtBOJ4A0/+uUIliorNrfYV6s1b02eQ==",
+      "version": "2.0.14",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/node-releases/-/node-releases-2.0.14.tgz",
+      "integrity": "sha1-L/sFO864sr6Elezhq2zmAMRGGws=",
       "dev": true
     },
     "node_modules/normalize-path": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
-      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha1-Dc1p/yOhybEf0JeDFmRKA4ghamU=",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -5165,8 +5097,8 @@
     },
     "node_modules/npm-run-path": {
       "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
-      "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/npm-run-path/-/npm-run-path-4.0.1.tgz",
+      "integrity": "sha1-t+zR5e1T2o43pV4cImnguX7XSOo=",
       "dev": true,
       "dependencies": {
         "path-key": "^3.0.0"
@@ -5177,37 +5109,37 @@
     },
     "node_modules/object-assign": {
       "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/object-inspect": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.0.tgz",
-      "integrity": "sha512-HQ4J+ic8hKrgIt3mqk6cVOVrW2ozL4KdvHlqpBv9vDYWx9ysAgENAdvy4FoGF+KFdhR7nQTNm5J0ctAeOwn+3g==",
+      "version": "1.13.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/object-inspect/-/object-inspect-1.13.1.tgz",
+      "integrity": "sha1-uWxhCTJMz+9rEiFqlWyk3C/5S8I=",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/object-keys": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
-      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/object-keys/-/object-keys-1.1.1.tgz",
+      "integrity": "sha1-HEfyct8nfzsdrwYWd9nILiMixg4=",
       "dev": true,
       "engines": {
         "node": ">= 0.4"
       }
     },
     "node_modules/object.assign": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.4.tgz",
-      "integrity": "sha512-1mxKf0e58bvyjSCtKYY4sRe9itRk3PJpquJOjeIkz885CczcI4IvJJDLPS72oowuSh+pBxUFROpX+TU++hxhZQ==",
+      "version": "4.1.5",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/object.assign/-/object.assign-4.1.5.tgz",
+      "integrity": "sha1-OoM/mrf9uA/J6NIwDIA9IW2P27A=",
       "dev": true,
       "dependencies": {
-        "call-bind": "^1.0.2",
-        "define-properties": "^1.1.4",
+        "call-bind": "^1.0.5",
+        "define-properties": "^1.2.1",
         "has-symbols": "^1.0.3",
         "object-keys": "^1.1.1"
       },
@@ -5219,28 +5151,29 @@
       }
     },
     "node_modules/object.entries": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.7.tgz",
-      "integrity": "sha512-jCBs/0plmPsOnrKAfFQXRG2NFjlhZgjjcBLSmTnEhU8U6vVTsVe8ANeQJCHTl3gSsI4J+0emOoCgoKlmQPMgmA==",
+      "version": "1.1.8",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/object.entries/-/object.entries-1.1.8.tgz",
+      "integrity": "sha1-v/5vKC4B9NF4ByBKJPjt2CNZnEE=",
       "dev": true,
       "dependencies": {
-        "call-bind": "^1.0.2",
-        "define-properties": "^1.2.0",
-        "es-abstract": "^1.22.1"
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.0.0"
       },
       "engines": {
         "node": ">= 0.4"
       }
     },
     "node_modules/object.fromentries": {
-      "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/object.fromentries/-/object.fromentries-2.0.7.tgz",
-      "integrity": "sha512-UPbPHML6sL8PI/mOqPwsH4G6iyXcCGzLin8KvEPenOZN5lpCNBZZQ+V62vdjB1mQHrmqGQt5/OJzemUA+KJmEA==",
+      "version": "2.0.8",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/object.fromentries/-/object.fromentries-2.0.8.tgz",
+      "integrity": "sha1-9xldipuXvZXLwZmeqTns0aKwDGU=",
       "dev": true,
       "dependencies": {
-        "call-bind": "^1.0.2",
-        "define-properties": "^1.2.0",
-        "es-abstract": "^1.22.1"
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.2",
+        "es-object-atoms": "^1.0.0"
       },
       "engines": {
         "node": ">= 0.4"
@@ -5250,26 +5183,28 @@
       }
     },
     "node_modules/object.groupby": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/object.groupby/-/object.groupby-1.0.1.tgz",
-      "integrity": "sha512-HqaQtqLnp/8Bn4GL16cj+CUYbnpe1bh0TtEaWvybszDG4tgxCJuRpV8VGuvNaI1fAnI4lUJzDG55MXcOH4JZcQ==",
+      "version": "1.0.3",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/object.groupby/-/object.groupby-1.0.3.tgz",
+      "integrity": "sha1-mxJcNiOBKfb3thlUoecXYUjVAC4=",
       "dev": true,
       "dependencies": {
-        "call-bind": "^1.0.2",
-        "define-properties": "^1.2.0",
-        "es-abstract": "^1.22.1",
-        "get-intrinsic": "^1.2.1"
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/object.values": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.1.7.tgz",
-      "integrity": "sha512-aU6xnDFYT3x17e/f0IiiwlGPTy2jzMySGfUB4fq6z7CV8l85CWHDk5ErhyhpfDHhrOMwGFhSQkhMGHaIotA6Ng==",
+      "version": "1.2.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/object.values/-/object.values-1.2.0.tgz",
+      "integrity": "sha1-ZUBanZLO5orC0wMALguEcKTZqxs=",
       "dev": true,
       "dependencies": {
-        "call-bind": "^1.0.2",
-        "define-properties": "^1.2.0",
-        "es-abstract": "^1.22.1"
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.0.0"
       },
       "engines": {
         "node": ">= 0.4"
@@ -5280,8 +5215,8 @@
     },
     "node_modules/on-finished": {
       "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
-      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha1-WMjEQRblSEWtV/FKsQsDUzGErD8=",
       "dependencies": {
         "ee-first": "1.1.1"
       },
@@ -5291,16 +5226,16 @@
     },
     "node_modules/once": {
       "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "dependencies": {
         "wrappy": "1"
       }
     },
     "node_modules/onetime": {
       "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
-      "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/onetime/-/onetime-5.1.2.tgz",
+      "integrity": "sha1-0Oluu1awdHbfHdnEgG5SN5hcpF4=",
       "dev": true,
       "dependencies": {
         "mimic-fn": "^2.1.0"
@@ -5313,17 +5248,17 @@
       }
     },
     "node_modules/optionator": {
-      "version": "0.9.3",
-      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.3.tgz",
-      "integrity": "sha512-JjCoypp+jKn1ttEFExxhetCKeJt9zhAgAve5FXHixTvFDW/5aEktX9bufBKLRRMdU7bNtpLfcGu94B3cdEJgjg==",
+      "version": "0.9.4",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/optionator/-/optionator-0.9.4.tgz",
+      "integrity": "sha1-fqHBpdkddk+yghOciP4R4YKjpzQ=",
       "dev": true,
       "dependencies": {
-        "@aashutoshrathi/word-wrap": "^1.2.3",
         "deep-is": "^0.1.3",
         "fast-levenshtein": "^2.0.6",
         "levn": "^0.4.1",
         "prelude-ls": "^1.2.1",
-        "type-check": "^0.4.0"
+        "type-check": "^0.4.0",
+        "word-wrap": "^1.2.5"
       },
       "engines": {
         "node": ">= 0.8.0"
@@ -5331,8 +5266,8 @@
     },
     "node_modules/p-limit": {
       "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
-      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha1-4drMvnjQ0TiMoYxk/qOOPlfjcGs=",
       "dev": true,
       "dependencies": {
         "yocto-queue": "^0.1.0"
@@ -5346,8 +5281,8 @@
     },
     "node_modules/p-locate": {
       "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
-      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha1-g8gxXGeFAF470CGDlBHJ4RDm2DQ=",
       "dev": true,
       "dependencies": {
         "p-limit": "^3.0.2"
@@ -5361,8 +5296,8 @@
     },
     "node_modules/p-try": {
       "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
-      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha1-yyhoVA4xPWHeWPr741zpAE1VQOY=",
       "dev": true,
       "engines": {
         "node": ">=6"
@@ -5370,8 +5305,8 @@
     },
     "node_modules/parent-module": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
-      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha1-aR0nCeeMefrjoVZiJFLQB2LKqqI=",
       "dev": true,
       "dependencies": {
         "callsites": "^3.0.0"
@@ -5382,8 +5317,8 @@
     },
     "node_modules/parse-json": {
       "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
-      "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/parse-json/-/parse-json-5.2.0.tgz",
+      "integrity": "sha1-x2/Gbe5UIxyWKyK8yKcs8vmXU80=",
       "dev": true,
       "dependencies": {
         "@babel/code-frame": "^7.0.0",
@@ -5400,16 +5335,16 @@
     },
     "node_modules/parseurl": {
       "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
-      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha1-naGee+6NEt/wUT7Vt2lXeTvC6NQ=",
       "engines": {
         "node": ">= 0.8"
       }
     },
     "node_modules/path-exists": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
-      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha1-UTvb4tO5XXdi6METfvoZXGxhtbM=",
       "dev": true,
       "engines": {
         "node": ">=8"
@@ -5417,16 +5352,16 @@
     },
     "node_modules/path-is-absolute": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/path-key": {
       "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
-      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha1-WB9q3mWMu6ZaDTOA3ndTKVBU83U=",
       "dev": true,
       "engines": {
         "node": ">=8"
@@ -5434,24 +5369,24 @@
     },
     "node_modules/path-parse": {
       "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
-      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha1-+8EUtgykKzDZ2vWFjkvWi77bZzU="
     },
     "node_modules/path-to-regexp": {
       "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
-      "integrity": "sha512-5DFkuoqlv1uYQKxy8omFBeJPQcdoE07Kv2sferDCrAq1ohOU+MSDswDIbnx3YAM60qIOnYa53wBhXW0EbMonrQ=="
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
+      "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w="
     },
     "node_modules/picocolors": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
-      "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
+      "version": "1.0.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/picocolors/-/picocolors-1.0.1.tgz",
+      "integrity": "sha1-qK1Xm1cZUvDl0liS3lRFvP4lqqE=",
       "dev": true
     },
     "node_modules/picomatch": {
       "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha1-O6ODNzNkbZ0+SZWUbBNlpn+wekI=",
       "dev": true,
       "engines": {
         "node": ">=8.6"
@@ -5462,8 +5397,8 @@
     },
     "node_modules/pirates": {
       "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.6.tgz",
-      "integrity": "sha512-saLsH7WeYYPiD25LDuLRRY/i+6HaPYr6G1OUlN39otzkSTxKnubR9RTxS3/Kk50s1g2JTgFwWQDQyplC5/SHZg==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/pirates/-/pirates-4.0.6.tgz",
+      "integrity": "sha1-MBiuMuz8/2wpuiJny/IRZqwfNrk=",
       "dev": true,
       "engines": {
         "node": ">= 6"
@@ -5471,8 +5406,8 @@
     },
     "node_modules/pkg-dir": {
       "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
-      "integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/pkg-dir/-/pkg-dir-4.2.0.tgz",
+      "integrity": "sha1-8JkTPfft5CLoHR2ESCcO6z5CYfM=",
       "dev": true,
       "dependencies": {
         "find-up": "^4.0.0"
@@ -5483,8 +5418,8 @@
     },
     "node_modules/pkg-dir/node_modules/find-up": {
       "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
-      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/find-up/-/find-up-4.1.0.tgz",
+      "integrity": "sha1-l6/n1s3AvFkoWEt8jXsW6KmqXRk=",
       "dev": true,
       "dependencies": {
         "locate-path": "^5.0.0",
@@ -5496,8 +5431,8 @@
     },
     "node_modules/pkg-dir/node_modules/locate-path": {
       "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
-      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/locate-path/-/locate-path-5.0.0.tgz",
+      "integrity": "sha1-Gvujlq/WdqbUJQTQpno6frn2KqA=",
       "dev": true,
       "dependencies": {
         "p-locate": "^4.1.0"
@@ -5508,8 +5443,8 @@
     },
     "node_modules/pkg-dir/node_modules/p-limit": {
       "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha1-PdM8ZHohT9//2DWTPrCG2g3CHbE=",
       "dev": true,
       "dependencies": {
         "p-try": "^2.0.0"
@@ -5523,8 +5458,8 @@
     },
     "node_modules/pkg-dir/node_modules/p-locate": {
       "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
-      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/p-locate/-/p-locate-4.1.0.tgz",
+      "integrity": "sha1-o0KLtwiLOmApL2aRkni3wpetTwc=",
       "dev": true,
       "dependencies": {
         "p-limit": "^2.2.0"
@@ -5533,10 +5468,19 @@
         "node": ">=8"
       }
     },
+    "node_modules/possible-typed-array-names": {
+      "version": "1.0.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/possible-typed-array-names/-/possible-typed-array-names-1.0.0.tgz",
+      "integrity": "sha1-ibtjxvraLD6QrcSmR77us5zHv48=",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
-      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/prelude-ls/-/prelude-ls-1.2.1.tgz",
+      "integrity": "sha1-3rxkidem5rDnYRiIzsiAM30xY5Y=",
       "dev": true,
       "engines": {
         "node": ">= 0.8.0"
@@ -5544,8 +5488,8 @@
     },
     "node_modules/pretty-format": {
       "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
-      "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/pretty-format/-/pretty-format-29.7.0.tgz",
+      "integrity": "sha1-ykLHWDEPNlv6caC9oKgHFgt3aBI=",
       "dev": true,
       "dependencies": {
         "@jest/schemas": "^29.6.3",
@@ -5558,8 +5502,8 @@
     },
     "node_modules/pretty-format/node_modules/ansi-styles": {
       "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha1-B0SWkK1Fd30ZJKwquy/IiV26g2s=",
       "dev": true,
       "engines": {
         "node": ">=10"
@@ -5570,16 +5514,16 @@
     },
     "node_modules/promise": {
       "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
-      "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/promise/-/promise-7.3.1.tgz",
+      "integrity": "sha1-BktyYCsY+Q8pGSuLG8QY/9Hr078=",
       "dependencies": {
         "asap": "~2.0.3"
       }
     },
     "node_modules/prompts": {
       "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
-      "integrity": "sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/prompts/-/prompts-2.4.2.tgz",
+      "integrity": "sha1-e1fnOzpIAprRDr1E90sBcipMsGk=",
       "dev": true,
       "dependencies": {
         "kleur": "^3.0.3",
@@ -5591,8 +5535,8 @@
     },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
-      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha1-8Z/mnOqzEe65S0LnDowgcPm6ECU=",
       "dependencies": {
         "forwarded": "0.2.0",
         "ipaddr.js": "1.9.1"
@@ -5648,8 +5592,8 @@
     },
     "node_modules/pug-filters": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/pug-filters/-/pug-filters-4.0.0.tgz",
-      "integrity": "sha512-yeNFtq5Yxmfz0f9z2rMXGw/8/4i1cCFecw/Q7+D0V2DdtII5UvqE12VaZ2AY7ri6o5RNXiweGH79OCq+2RQU4A==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/pug-filters/-/pug-filters-4.0.0.tgz",
+      "integrity": "sha1-0+Sa9bqEcum3pm2YDnB86dLMm14=",
       "dependencies": {
         "constantinople": "^4.0.1",
         "jstransformer": "1.0.0",
@@ -5660,8 +5604,8 @@
     },
     "node_modules/pug-lexer": {
       "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/pug-lexer/-/pug-lexer-5.0.1.tgz",
-      "integrity": "sha512-0I6C62+keXlZPZkOJeVam9aBLVP2EnbeDw3An+k0/QlqdwH6rv8284nko14Na7c0TtqtogfWXcRoFE4O4Ff20w==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/pug-lexer/-/pug-lexer-5.0.1.tgz",
+      "integrity": "sha1-rkRijFvvmxkLZlaDsojKkCS4sNU=",
       "dependencies": {
         "character-parser": "^2.2.0",
         "is-expression": "^4.0.0",
@@ -5670,8 +5614,8 @@
     },
     "node_modules/pug-linker": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/pug-linker/-/pug-linker-4.0.0.tgz",
-      "integrity": "sha512-gjD1yzp0yxbQqnzBAdlhbgoJL5qIFJw78juN1NpTLt/mfPJ5VgC4BvkoD3G23qKzJtIIXBbcCt6FioLSFLOHdw==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/pug-linker/-/pug-linker-4.0.0.tgz",
+      "integrity": "sha1-EsvAWU/Fo+Brn8Web5PBRpYqdwg=",
       "dependencies": {
         "pug-error": "^2.0.0",
         "pug-walk": "^2.0.0"
@@ -5679,8 +5623,8 @@
     },
     "node_modules/pug-load": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/pug-load/-/pug-load-3.0.0.tgz",
-      "integrity": "sha512-OCjTEnhLWZBvS4zni/WUMjH2YSUosnsmjGBB1An7CsKQarYSWQ0GCVyd4eQPMFJqZ8w9xgs01QdiZXKVjk92EQ==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/pug-load/-/pug-load-3.0.0.tgz",
+      "integrity": "sha1-n9nNpSICsIrbEdJWgfufNL1BtmI=",
       "dependencies": {
         "object-assign": "^4.1.1",
         "pug-walk": "^2.0.0"
@@ -5688,8 +5632,8 @@
     },
     "node_modules/pug-parser": {
       "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/pug-parser/-/pug-parser-6.0.0.tgz",
-      "integrity": "sha512-ukiYM/9cH6Cml+AOl5kETtM9NR3WulyVP2y4HOU45DyMim1IeP/OOiyEWRr6qk5I5klpsBnbuHpwKmTx6WURnw==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/pug-parser/-/pug-parser-6.0.0.tgz",
+      "integrity": "sha1-qP3ANYY6lbLB3F6/Ts+AtOdqEmA=",
       "dependencies": {
         "pug-error": "^2.0.0",
         "token-stream": "1.0.0"
@@ -5702,30 +5646,30 @@
     },
     "node_modules/pug-strip-comments": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/pug-strip-comments/-/pug-strip-comments-2.0.0.tgz",
-      "integrity": "sha512-zo8DsDpH7eTkPHCXFeAk1xZXJbyoTfdPlNR0bK7rpOMuhBYb0f5qUVCO1xlsitYd3w5FQTK7zpNVKb3rZoUrrQ==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/pug-strip-comments/-/pug-strip-comments-2.0.0.tgz",
+      "integrity": "sha1-+UsH/WtJVSMzD0kKf1VLT/h2MD4=",
       "dependencies": {
         "pug-error": "^2.0.0"
       }
     },
     "node_modules/pug-walk": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/pug-walk/-/pug-walk-2.0.0.tgz",
-      "integrity": "sha512-yYELe9Q5q9IQhuvqsZNwA5hfPkMJ8u92bQLIMcsMxf/VADjNtEYptU+inlufAFYcWdHlwNfZOEnOOQrZrcyJCQ=="
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/pug-walk/-/pug-walk-2.0.0.tgz",
+      "integrity": "sha1-QXqrwpIyu0SZtbUGmistKiTV9f4="
     },
     "node_modules/punycode": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.0.tgz",
-      "integrity": "sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA==",
+      "version": "2.3.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha1-AnQi4vrsCyXhVJw+G9gwm5EztuU=",
       "dev": true,
       "engines": {
         "node": ">=6"
       }
     },
     "node_modules/pure-rand": {
-      "version": "6.0.4",
-      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-6.0.4.tgz",
-      "integrity": "sha512-LA0Y9kxMYv47GIPJy6MI84fqTd2HmYZI83W/kM/SkKfDlajnZYfmXFTxkbY+xSBPkLJxltMa9hIkmdc29eguMA==",
+      "version": "6.1.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/pure-rand/-/pure-rand-6.1.0.tgz",
+      "integrity": "sha1-0XPPIyWCMZdsy9sFJHyXh5V2BPI=",
       "dev": true,
       "funding": [
         {
@@ -5740,8 +5684,8 @@
     },
     "node_modules/qs": {
       "version": "6.11.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.11.0.tgz",
-      "integrity": "sha512-MvjoMCJwEarSbUYk5O+nmoSzSutSsTwF85zcHPQ9OrlFoZOYIjaqBAJIqIXjptyD5vThxGq52Xu/MaJzRkIk4Q==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/qs/-/qs-6.11.0.tgz",
+      "integrity": "sha1-/Q2WNEb3pl4TZ+AavYVClFPww3o=",
       "dependencies": {
         "side-channel": "^1.0.4"
       },
@@ -5754,8 +5698,8 @@
     },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
-      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/queue-microtask/-/queue-microtask-1.2.3.tgz",
+      "integrity": "sha1-SSkii7xyTfrEPg77BYyve2z7YkM=",
       "dev": true,
       "funding": [
         {
@@ -5774,16 +5718,16 @@
     },
     "node_modules/range-parser": {
       "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
-      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha1-PPNwI9GZ4cJNGlW4SADC8+ZGgDE=",
       "engines": {
         "node": ">= 0.6"
       }
     },
     "node_modules/raw-body": {
       "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.2.tgz",
-      "integrity": "sha512-8zGqypfENjCIqGhgXToC8aB2r7YrBX+AQAfIPs/Mlk+BtPTztOvTS01NRW/3Eh60J+a48lt8qsCzirQ6loCVfA==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/raw-body/-/raw-body-2.5.2.tgz",
+      "integrity": "sha1-mf69g7kOCJdQh+jx+UGaFJNmtoo=",
       "dependencies": {
         "bytes": "3.1.2",
         "http-errors": "2.0.0",
@@ -5795,15 +5739,15 @@
       }
     },
     "node_modules/react-is": {
-      "version": "18.2.0",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
-      "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==",
+      "version": "18.3.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha1-6DVX3BLq5jqZ4AOkY4ix3LtE234=",
       "dev": true
     },
     "node_modules/redis": {
       "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/redis/-/redis-3.1.2.tgz",
-      "integrity": "sha512-grn5KoZLr/qrRQVwoSkmzdbw6pwF+/rwODtrOr6vuBRiR/f3rjSTGupbF90Zpqm2oenix8Do6RV7pYEkGwlKkw==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/redis/-/redis-3.1.2.tgz",
+      "integrity": "sha1-dmhREX6AZT0j4O1TYlRnerZHY4w=",
       "dependencies": {
         "denque": "^1.5.0",
         "redis-commands": "^1.7.0",
@@ -5820,21 +5764,21 @@
     },
     "node_modules/redis-commands": {
       "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/redis-commands/-/redis-commands-1.7.0.tgz",
-      "integrity": "sha512-nJWqw3bTFy21hX/CPKHth6sfhZbdiHP6bTawSgQBlKOVRG7EZkfHbbHwQJnrE4vsQf0CMNE+3gJ4Fmm16vdVlQ=="
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/redis-commands/-/redis-commands-1.7.0.tgz",
+      "integrity": "sha1-Fab+otWCgeJ7HNGs+0spPieMOok="
     },
     "node_modules/redis-errors": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/redis-errors/-/redis-errors-1.2.0.tgz",
-      "integrity": "sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/redis-errors/-/redis-errors-1.2.0.tgz",
+      "integrity": "sha1-62LSrbFeTq9GEMBK/hUpOEJQq60=",
       "engines": {
         "node": ">=4"
       }
     },
     "node_modules/redis-parser": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-3.0.0.tgz",
-      "integrity": "sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/redis-parser/-/redis-parser-3.0.0.tgz",
+      "integrity": "sha1-tm2CjNyv5rS4pCin3vTGvKwxyLQ=",
       "dependencies": {
         "redis-errors": "^1.0.0"
       },
@@ -5843,14 +5787,15 @@
       }
     },
     "node_modules/regexp.prototype.flags": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.1.tgz",
-      "integrity": "sha512-sy6TXMN+hnP/wMy+ISxg3krXx7BAtWVO4UouuCN/ziM9UEne0euamVNafDfvC83bRNr95y0V5iijeDQFUNpvrg==",
+      "version": "1.5.2",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/regexp.prototype.flags/-/regexp.prototype.flags-1.5.2.tgz",
+      "integrity": "sha1-E49kSjNQ+YGoWMRPa7GmH/Wb4zQ=",
       "dev": true,
       "dependencies": {
-        "call-bind": "^1.0.2",
-        "define-properties": "^1.2.0",
-        "set-function-name": "^2.0.0"
+        "call-bind": "^1.0.6",
+        "define-properties": "^1.2.1",
+        "es-errors": "^1.3.0",
+        "set-function-name": "^2.0.1"
       },
       "engines": {
         "node": ">= 0.4"
@@ -5861,16 +5806,16 @@
     },
     "node_modules/require-directory": {
       "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/resolve": {
       "version": "1.22.8",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.8.tgz",
-      "integrity": "sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/resolve/-/resolve-1.22.8.tgz",
+      "integrity": "sha1-tsh6nyqgbfq1Lj1wrIzeMh+lpI0=",
       "dependencies": {
         "is-core-module": "^2.13.0",
         "path-parse": "^1.0.7",
@@ -5885,8 +5830,8 @@
     },
     "node_modules/resolve-cwd": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-3.0.0.tgz",
-      "integrity": "sha512-OrZaX2Mb+rJCpH/6CpSqt9xFVpN++x01XnN2ie9g6P5/3xelLAkXWVADpdz1IHD/KFfEXyE6V0U01OQ3UO2rEg==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/resolve-cwd/-/resolve-cwd-3.0.0.tgz",
+      "integrity": "sha1-DwB18bslRHZs9zumpuKt/ryxPy0=",
       "dev": true,
       "dependencies": {
         "resolve-from": "^5.0.0"
@@ -5897,8 +5842,8 @@
     },
     "node_modules/resolve-cwd/node_modules/resolve-from": {
       "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
-      "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/resolve-from/-/resolve-from-5.0.0.tgz",
+      "integrity": "sha1-w1IlhD3493bfIcV1V7wIfp39/Gk=",
       "dev": true,
       "engines": {
         "node": ">=8"
@@ -5906,8 +5851,8 @@
     },
     "node_modules/resolve-from": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
-      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha1-SrzYUq0y3Xuqv+m0DgCjbbXzkuY=",
       "dev": true,
       "engines": {
         "node": ">=4"
@@ -5915,14 +5860,13 @@
     },
     "node_modules/resolve-url": {
       "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
-      "integrity": "sha512-ZuF55hVUQaaczgOIwqWzkEcEidmlD/xl44x1UZnhOXcYuFN2S6+rcxpG+C1N3So0wvNI3DmJICUFfu2SxhBmvg==",
-      "deprecated": "https://github.com/lydell/resolve-url#deprecated"
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/resolve-url/-/resolve-url-0.2.1.tgz",
+      "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo="
     },
     "node_modules/resolve.exports": {
       "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/resolve.exports/-/resolve.exports-2.0.2.tgz",
-      "integrity": "sha512-X2UW6Nw3n/aMgDVy+0rSqgHlv39WZAlZrXCdnbyEiKm17DSqHX4MmQMaST3FbeWR5FTuRcUwYAziZajji0Y7mg==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/resolve.exports/-/resolve.exports-2.0.2.tgz",
+      "integrity": "sha1-+Mk0uOahP1OeOLcJji42E08B6AA=",
       "dev": true,
       "engines": {
         "node": ">=10"
@@ -5938,8 +5882,8 @@
     },
     "node_modules/reusify": {
       "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
-      "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/reusify/-/reusify-1.0.4.tgz",
+      "integrity": "sha1-kNo4Kx4SbvwCFG6QhFqI2xKSXXY=",
       "dev": true,
       "engines": {
         "iojs": ">=1.0.0",
@@ -5948,8 +5892,8 @@
     },
     "node_modules/rimraf": {
       "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha1-8aVAK6YiCtUswSgrrBrjqkn9Bho=",
       "dev": true,
       "dependencies": {
         "glob": "^7.1.3"
@@ -5963,8 +5907,8 @@
     },
     "node_modules/run-parallel": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
-      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/run-parallel/-/run-parallel-1.2.0.tgz",
+      "integrity": "sha1-ZtE2jae9+SHrnZW9GpIp5/IaQ+4=",
       "dev": true,
       "funding": [
         {
@@ -5985,13 +5929,13 @@
       }
     },
     "node_modules/safe-array-concat": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.0.1.tgz",
-      "integrity": "sha512-6XbUAseYE2KtOuGueyeobCySj9L4+66Tn6KQMOPQJrAJEowYKW/YR/MGJZl7FdydUdaFu4LYyDZjxf4/Nmo23Q==",
+      "version": "1.1.2",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/safe-array-concat/-/safe-array-concat-1.1.2.tgz",
+      "integrity": "sha1-gdd+4MTouGNjUifHISeN1STCDts=",
       "dev": true,
       "dependencies": {
-        "call-bind": "^1.0.2",
-        "get-intrinsic": "^1.2.1",
+        "call-bind": "^1.0.7",
+        "get-intrinsic": "^1.2.4",
         "has-symbols": "^1.0.3",
         "isarray": "^2.0.5"
       },
@@ -6004,8 +5948,8 @@
     },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha1-Hq+fqb2x/dTsdfWPnNtOa3gn7sY=",
       "funding": [
         {
           "type": "github",
@@ -6022,14 +5966,17 @@
       ]
     },
     "node_modules/safe-regex-test": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.0.0.tgz",
-      "integrity": "sha512-JBUUzyOgEwXQY1NuPtvcj/qcBDbDmEvWufhlnXZIm75DEHp+afM1r1ujJpJsV/gSM4t59tpDyPi1sd6ZaPFfsA==",
+      "version": "1.0.3",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/safe-regex-test/-/safe-regex-test-1.0.3.tgz",
+      "integrity": "sha1-pbTA8G4KtQ6iw5XBTYNxIykkw3c=",
       "dev": true,
       "dependencies": {
-        "call-bind": "^1.0.2",
-        "get-intrinsic": "^1.1.3",
+        "call-bind": "^1.0.6",
+        "es-errors": "^1.3.0",
         "is-regex": "^1.1.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -6037,26 +5984,26 @@
     },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha1-RPoWGwGHuVSd2Eu5GAL5vYOFzWo="
     },
     "node_modules/sax": {
       "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
-      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/sax/-/sax-1.2.4.tgz",
+      "integrity": "sha1-KBYjTiN4vdxOU1T6tcqold9xANk="
     },
     "node_modules/semver": {
       "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha1-VW0u+GiRRuRtzqS/3QlfNDTf/LQ=",
       "bin": {
         "semver": "bin/semver.js"
       }
     },
     "node_modules/send": {
       "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/send/-/send-0.18.0.tgz",
-      "integrity": "sha512-qqWzuOjSFOuqPjFe4NOsMLafToQQwBSOEpS+FwEt3A2V3vKubTquT3vmLTQpFgMXp8AlFWFuP1qKaJZOtPpVXg==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/send/-/send-0.18.0.tgz",
+      "integrity": "sha1-ZwFnzGVLBfWqSnZ/kRO7NxvHBr4=",
       "dependencies": {
         "debug": "2.6.9",
         "depd": "2.0.0",
@@ -6078,13 +6025,13 @@
     },
     "node_modules/send/node_modules/ms": {
       "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha1-V0yBOM4dK1hh8LRFedut1gxmFbI="
     },
     "node_modules/serve-static": {
       "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.15.0.tgz",
-      "integrity": "sha512-XGuRDNjXUijsUL0vl6nSD7cwURuzEgglbOaFuZM9g3kwDXOWVTck0jLzjPzGD+TazWbboZYu52/9/XPdUgne9g==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/serve-static/-/serve-static-1.15.0.tgz",
+      "integrity": "sha1-+q7wjP/goaYvYMrQxOUTz/CslUA=",
       "dependencies": {
         "encodeurl": "~1.0.2",
         "escape-html": "~1.0.3",
@@ -6095,15 +6042,32 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/set-function-length": {
+      "version": "1.2.2",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/set-function-length/-/set-function-length-1.2.2.tgz",
+      "integrity": "sha1-qscjFBmOrtl1z3eyw7a4gGleVEk=",
+      "dependencies": {
+        "define-data-property": "^1.1.4",
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2",
+        "get-intrinsic": "^1.2.4",
+        "gopd": "^1.0.1",
+        "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/set-function-name": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/set-function-name/-/set-function-name-2.0.1.tgz",
-      "integrity": "sha512-tMNCiqYVkXIZgc2Hnoy2IvC/f8ezc5koaRFkCjrpWzGpCd3qbZXPzVy9MAZzK1ch/X0jvSkojys3oqJN0qCmdA==",
+      "version": "2.0.2",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/set-function-name/-/set-function-name-2.0.2.tgz",
+      "integrity": "sha1-FqcFxaDcL15jjKltiozU4cK5CYU=",
       "dev": true,
       "dependencies": {
-        "define-data-property": "^1.0.1",
+        "define-data-property": "^1.1.4",
+        "es-errors": "^1.3.0",
         "functions-have-names": "^1.2.3",
-        "has-property-descriptors": "^1.0.0"
+        "has-property-descriptors": "^1.0.2"
       },
       "engines": {
         "node": ">= 0.4"
@@ -6111,13 +6075,13 @@
     },
     "node_modules/setprototypeof": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
-      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha1-ZsmiSnP5/CjL5msJ/tPTPcrxtCQ="
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
-      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha1-zNCvT4g1+9wmW4JGGq8MNmY/NOo=",
       "dev": true,
       "dependencies": {
         "shebang-regex": "^3.0.0"
@@ -6128,21 +6092,25 @@
     },
     "node_modules/shebang-regex": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
-      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha1-rhbxZE2HPsrYQ7AwexQzYtTEIXI=",
       "dev": true,
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/side-channel": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
-      "integrity": "sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==",
+      "version": "1.0.6",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/side-channel/-/side-channel-1.0.6.tgz",
+      "integrity": "sha1-q9Jft80kuvRUZkBrEJa3gxySFfI=",
       "dependencies": {
-        "call-bind": "^1.0.0",
-        "get-intrinsic": "^1.0.2",
-        "object-inspect": "^1.9.0"
+        "call-bind": "^1.0.7",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.4",
+        "object-inspect": "^1.13.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -6150,20 +6118,20 @@
     },
     "node_modules/signal-exit": {
       "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
-      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha1-qaF2f4r4QVURTqq9c/mSc8j1mtk=",
       "dev": true
     },
     "node_modules/sisteransi": {
       "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
-      "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/sisteransi/-/sisteransi-1.0.5.tgz",
+      "integrity": "sha1-E01oEpd1ZDfMBcoBNw06elcQde0=",
       "dev": true
     },
     "node_modules/slash": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
-      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/slash/-/slash-3.0.0.tgz",
+      "integrity": "sha1-ZTm+hwwWWtvVJAIg2+Nh8bxNRjQ=",
       "dev": true,
       "engines": {
         "node": ">=8"
@@ -6171,17 +6139,16 @@
     },
     "node_modules/source-map": {
       "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/source-map-resolve": {
       "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.3.tgz",
-      "integrity": "sha512-Htz+RnsXWk5+P2slx5Jh3Q66vhQj1Cllm0zvnaY98+NFx+Dv2CF/f5O/t8x+KaNdrdIAsruNzoh/KpialbqAnw==",
-      "deprecated": "See https://github.com/lydell/source-map-resolve#deprecated",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/source-map-resolve/-/source-map-resolve-0.5.3.tgz",
+      "integrity": "sha1-GQhmvs51U+H48mei7oLGBrVQmho=",
       "dependencies": {
         "atob": "^2.1.2",
         "decode-uri-component": "^0.2.0",
@@ -6192,8 +6159,8 @@
     },
     "node_modules/source-map-support": {
       "version": "0.5.13",
-      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.13.tgz",
-      "integrity": "sha512-SHSKFHadjVA5oR4PPqhtAVdcBWwRYVd6g6cAXnIbRiIwc2EhPrTuKUBdSLvlEKyIP3GCf89fltvcZiP9MMFA1w==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/source-map-support/-/source-map-support-0.5.13.tgz",
+      "integrity": "sha1-MbJKnC5zwt6FBmwP631Edn7VKTI=",
       "dev": true,
       "dependencies": {
         "buffer-from": "^1.0.0",
@@ -6202,20 +6169,19 @@
     },
     "node_modules/source-map-url": {
       "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.1.tgz",
-      "integrity": "sha512-cPiFOTLUKvJFIg4SKVScy4ilPPW6rFgMgfuZJPNoDuMs3nC1HbMUycBoJw77xFIp6z1UJQJOfx6C9GMH80DiTw==",
-      "deprecated": "See https://github.com/lydell/source-map-url#deprecated"
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/source-map-url/-/source-map-url-0.4.1.tgz",
+      "integrity": "sha1-CvZmBadFpaL5HPG7+KevvCg97FY="
     },
     "node_modules/sprintf-js": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
       "dev": true
     },
     "node_modules/stack-utils": {
       "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.6.tgz",
-      "integrity": "sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/stack-utils/-/stack-utils-2.0.6.tgz",
+      "integrity": "sha1-qvB0gWnAL8M8gjKrzPkz9Uocw08=",
       "dev": true,
       "dependencies": {
         "escape-string-regexp": "^2.0.0"
@@ -6226,8 +6192,8 @@
     },
     "node_modules/stack-utils/node_modules/escape-string-regexp": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
-      "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
+      "integrity": "sha1-owME6Z2qMuI7L9IPUbq9B8/8o0Q=",
       "dev": true,
       "engines": {
         "node": ">=8"
@@ -6235,16 +6201,16 @@
     },
     "node_modules/statuses": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
-      "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/statuses/-/statuses-2.0.1.tgz",
+      "integrity": "sha1-VcsADM8dSHKL0jxoWgY5mM8aG2M=",
       "engines": {
         "node": ">= 0.8"
       }
     },
     "node_modules/string-length": {
       "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/string-length/-/string-length-4.0.2.tgz",
-      "integrity": "sha512-+l6rNN5fYHNhZZy41RXsYptCjA2Igmq4EG7kZAYFQI1E1VTXarr6ZPXBg6eq7Y6eK4FEhY6AJlyuFIb/v/S0VQ==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/string-length/-/string-length-4.0.2.tgz",
+      "integrity": "sha1-qKjce9XBqCubPIuH4SX2aHG25Xo=",
       "dev": true,
       "dependencies": {
         "char-regex": "^1.0.2",
@@ -6256,8 +6222,8 @@
     },
     "node_modules/string-width": {
       "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha1-JpxxF9J7Ba0uU2gwqOyJXvnG0BA=",
       "dependencies": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
@@ -6268,14 +6234,15 @@
       }
     },
     "node_modules/string.prototype.trim": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.8.tgz",
-      "integrity": "sha512-lfjY4HcixfQXOfaqCvcBuOIapyaroTXhbkfJN3gcB1OtyupngWK4sEET9Knd0cXd28kTUqu/kHoV4HKSJdnjiQ==",
+      "version": "1.2.9",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/string.prototype.trim/-/string.prototype.trim-1.2.9.tgz",
+      "integrity": "sha1-tvoybXLSx4tt8C93Wcc/j2J0+qQ=",
       "dev": true,
       "dependencies": {
-        "call-bind": "^1.0.2",
-        "define-properties": "^1.2.0",
-        "es-abstract": "^1.22.1"
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.0",
+        "es-object-atoms": "^1.0.0"
       },
       "engines": {
         "node": ">= 0.4"
@@ -6285,28 +6252,31 @@
       }
     },
     "node_modules/string.prototype.trimend": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.7.tgz",
-      "integrity": "sha512-Ni79DqeB72ZFq1uH/L6zJ+DKZTkOtPIHovb3YZHQViE+HDouuU4mBrLOLDn5Dde3RF8qw5qVETEjhu9locMLvA==",
+      "version": "1.0.8",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/string.prototype.trimend/-/string.prototype.trimend-1.0.8.tgz",
+      "integrity": "sha1-NlG4UTcZ6Kn0jefy93ZAsmZSsik=",
       "dev": true,
       "dependencies": {
-        "call-bind": "^1.0.2",
-        "define-properties": "^1.2.0",
-        "es-abstract": "^1.22.1"
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.0.0"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/string.prototype.trimstart": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.7.tgz",
-      "integrity": "sha512-NGhtDFu3jCEm7B4Fy0DpLewdJQOZcQ0rGbwQ/+stjnrp2i+rlKeCvos9hOIeCmqwratM47OBxY7uFZzjxHXmrg==",
+      "version": "1.0.8",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/string.prototype.trimstart/-/string.prototype.trimstart-1.0.8.tgz",
+      "integrity": "sha1-fug03ajHwX7/MRhHK7Nb/tqjTd4=",
       "dev": true,
       "dependencies": {
-        "call-bind": "^1.0.2",
-        "define-properties": "^1.2.0",
-        "es-abstract": "^1.22.1"
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -6314,8 +6284,8 @@
     },
     "node_modules/strip-ansi": {
       "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha1-nibGPTD1NEPpSJSVshBdN7Z6hdk=",
       "dependencies": {
         "ansi-regex": "^5.0.1"
       },
@@ -6325,8 +6295,8 @@
     },
     "node_modules/strip-bom": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-4.0.0.tgz",
-      "integrity": "sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/strip-bom/-/strip-bom-4.0.0.tgz",
+      "integrity": "sha1-nDUFwdtFvO3KPZz3oW9cWqOQGHg=",
       "dev": true,
       "engines": {
         "node": ">=8"
@@ -6334,8 +6304,8 @@
     },
     "node_modules/strip-final-newline": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
-      "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
+      "integrity": "sha1-ibhS+y/L6Tb29LMYevsKEsGrWK0=",
       "dev": true,
       "engines": {
         "node": ">=6"
@@ -6343,8 +6313,8 @@
     },
     "node_modules/strip-json-comments": {
       "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
-      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha1-MfEoGzgyYwQ0gxwxDAHMzajL4AY=",
       "dev": true,
       "engines": {
         "node": ">=8"
@@ -6355,8 +6325,8 @@
     },
     "node_modules/stylus": {
       "version": "0.54.8",
-      "resolved": "https://registry.npmjs.org/stylus/-/stylus-0.54.8.tgz",
-      "integrity": "sha512-vr54Or4BZ7pJafo2mpf0ZcwA74rpuYCZbxrHBsH8kbcXOwSfvBFwsRfpGO5OD5fhG5HDCFW737PKaawI7OqEAg==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/stylus/-/stylus-0.54.8.tgz",
+      "integrity": "sha1-PaPmWWa8Vnp7BEv+DuzmU+CZ0Uc=",
       "dependencies": {
         "css-parse": "~2.0.0",
         "debug": "~3.1.0",
@@ -6376,24 +6346,24 @@
     },
     "node_modules/stylus/node_modules/debug": {
       "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-      "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/debug/-/debug-3.1.0.tgz",
+      "integrity": "sha1-W7WgZyYotkFJVmuhaBnmFRjGcmE=",
       "dependencies": {
         "ms": "2.0.0"
       }
     },
     "node_modules/stylus/node_modules/source-map": {
       "version": "0.7.4",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.4.tgz",
-      "integrity": "sha512-l3BikUxvPOcn5E74dZiq5BGsTb5yEwhaTSzccU6t4sDOH8NWJCstKO5QT2CvtFoK6F0saL7p9xHAqHOlCPJygA==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/source-map/-/source-map-0.7.4.tgz",
+      "integrity": "sha1-qbvnBcnYhG9OCP9nZazw8bCJhlY=",
       "engines": {
         "node": ">= 8"
       }
     },
     "node_modules/supports-color": {
       "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha1-G33NyzK4E4gBs+R4umpRyqiWSNo=",
       "dev": true,
       "dependencies": {
         "has-flag": "^4.0.0"
@@ -6404,8 +6374,8 @@
     },
     "node_modules/supports-preserve-symlinks-flag": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
-      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "integrity": "sha1-btpL00SjyUrqN21MwxvHcxEDngk=",
       "engines": {
         "node": ">= 0.4"
       },
@@ -6415,8 +6385,8 @@
     },
     "node_modules/test-exclude": {
       "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-6.0.0.tgz",
-      "integrity": "sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/test-exclude/-/test-exclude-6.0.0.tgz",
+      "integrity": "sha1-BKhphmHYBepvopO2y55jrARO8V4=",
       "dev": true,
       "dependencies": {
         "@istanbuljs/schema": "^0.1.2",
@@ -6429,28 +6399,28 @@
     },
     "node_modules/text-table": {
       "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
-      "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/text-table/-/text-table-0.2.0.tgz",
+      "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
       "dev": true
     },
     "node_modules/tmpl": {
       "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
-      "integrity": "sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/tmpl/-/tmpl-1.0.5.tgz",
+      "integrity": "sha1-hoPguQK7nCDE9ybjwLafNlGMB8w=",
       "dev": true
     },
     "node_modules/to-fast-properties": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-      "integrity": "sha512-/OaKK0xYrs3DmxRYqL/yDc+FxFUVYhDlXMhRmv3z915w2HF1tnN1omB354j8VUGO/hbRzyD6Y3sA7v7GS/ceog==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+      "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
       "engines": {
         "node": ">=4"
       }
     },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
-      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha1-FkjESq58jZiKMmAY7XL1tN0DkuQ=",
       "dev": true,
       "dependencies": {
         "is-number": "^7.0.0"
@@ -6461,21 +6431,21 @@
     },
     "node_modules/toidentifier": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
-      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha1-O+NDIaiKgg7RvYDfqjPkefu43TU=",
       "engines": {
         "node": ">=0.6"
       }
     },
     "node_modules/token-stream": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/token-stream/-/token-stream-1.0.0.tgz",
-      "integrity": "sha512-VSsyNPPW74RpHwR8Fc21uubwHY7wMDeJLys2IX5zJNih+OnAnaifKHo+1LHT7DAdloQ7apeaaWg8l7qnf/TnEg=="
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/token-stream/-/token-stream-1.0.0.tgz",
+      "integrity": "sha1-zCAOqyYT9BZtJ/+a/HylbUnfbrQ="
     },
     "node_modules/tsconfig-paths": {
-      "version": "3.14.2",
-      "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.14.2.tgz",
-      "integrity": "sha512-o/9iXgCYc5L/JxCHPe3Hvh8Q/2xm5Z+p18PESBU6Ff33695QnCHBEjcytY2q19ua7Mbl/DavtBOLq+oG0RCL+g==",
+      "version": "3.15.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/tsconfig-paths/-/tsconfig-paths-3.15.0.tgz",
+      "integrity": "sha1-UpnsYF5VsauyPsk57xXtr0gwcNQ=",
       "dev": true,
       "dependencies": {
         "@types/json5": "^0.0.29",
@@ -6486,8 +6456,8 @@
     },
     "node_modules/tsconfig-paths/node_modules/json5": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
-      "integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/json5/-/json5-1.0.2.tgz",
+      "integrity": "sha1-Y9mNYPIbMTt3xNbaGL+mnYDh1ZM=",
       "dev": true,
       "dependencies": {
         "minimist": "^1.2.0"
@@ -6498,8 +6468,8 @@
     },
     "node_modules/tsconfig-paths/node_modules/strip-bom": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-      "integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/strip-bom/-/strip-bom-3.0.0.tgz",
+      "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
       "dev": true,
       "engines": {
         "node": ">=4"
@@ -6507,8 +6477,8 @@
     },
     "node_modules/type-check": {
       "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
-      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/type-check/-/type-check-0.4.0.tgz",
+      "integrity": "sha1-B7ggO/pwVsBlcFDjzNLDdzC6uPE=",
       "dev": true,
       "dependencies": {
         "prelude-ls": "^1.2.1"
@@ -6519,8 +6489,8 @@
     },
     "node_modules/type-detect": {
       "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
-      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha1-dkb7XxiHHPu3dJ5pvTmmOI63RQw=",
       "dev": true,
       "engines": {
         "node": ">=4"
@@ -6528,8 +6498,8 @@
     },
     "node_modules/type-fest": {
       "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
-      "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/type-fest/-/type-fest-0.20.2.tgz",
+      "integrity": "sha1-G/IH9LKPkVg2ZstfvTJ4hzAc1fQ=",
       "dev": true,
       "engines": {
         "node": ">=10"
@@ -6540,8 +6510,8 @@
     },
     "node_modules/type-is": {
       "version": "1.6.18",
-      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
-      "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/type-is/-/type-is-1.6.18.tgz",
+      "integrity": "sha1-TlUs0F3wlGfcvE73Od6J8s83wTE=",
       "dependencies": {
         "media-typer": "0.3.0",
         "mime-types": "~2.1.24"
@@ -6551,29 +6521,30 @@
       }
     },
     "node_modules/typed-array-buffer": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.0.tgz",
-      "integrity": "sha512-Y8KTSIglk9OZEr8zywiIHG/kmQ7KWyjseXs1CbSo8vC42w7hg2HgYTxSWwP0+is7bWDc1H+Fo026CpHFwm8tkw==",
+      "version": "1.0.2",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/typed-array-buffer/-/typed-array-buffer-1.0.2.tgz",
+      "integrity": "sha1-GGfF2Dsg/LXM8yZJ5eL8dCRHT/M=",
       "dev": true,
       "dependencies": {
-        "call-bind": "^1.0.2",
-        "get-intrinsic": "^1.2.1",
-        "is-typed-array": "^1.1.10"
+        "call-bind": "^1.0.7",
+        "es-errors": "^1.3.0",
+        "is-typed-array": "^1.1.13"
       },
       "engines": {
         "node": ">= 0.4"
       }
     },
     "node_modules/typed-array-byte-length": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/typed-array-byte-length/-/typed-array-byte-length-1.0.0.tgz",
-      "integrity": "sha512-Or/+kvLxNpeQ9DtSydonMxCx+9ZXOswtwJn17SNLvhptaXYDJvkFFP5zbfU/uLmvnBJlI4yrnXRxpdWH/M5tNA==",
+      "version": "1.0.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/typed-array-byte-length/-/typed-array-byte-length-1.0.1.tgz",
+      "integrity": "sha1-2Sly08/5mj+i52Wij83A8did7Gc=",
       "dev": true,
       "dependencies": {
-        "call-bind": "^1.0.2",
+        "call-bind": "^1.0.7",
         "for-each": "^0.3.3",
-        "has-proto": "^1.0.1",
-        "is-typed-array": "^1.1.10"
+        "gopd": "^1.0.1",
+        "has-proto": "^1.0.3",
+        "is-typed-array": "^1.1.13"
       },
       "engines": {
         "node": ">= 0.4"
@@ -6583,16 +6554,17 @@
       }
     },
     "node_modules/typed-array-byte-offset": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/typed-array-byte-offset/-/typed-array-byte-offset-1.0.0.tgz",
-      "integrity": "sha512-RD97prjEt9EL8YgAgpOkf3O4IF9lhJFr9g0htQkm0rchFp/Vx7LW5Q8fSXXub7BXAODyUQohRMyOc3faCPd0hg==",
+      "version": "1.0.2",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/typed-array-byte-offset/-/typed-array-byte-offset-1.0.2.tgz",
+      "integrity": "sha1-+eway5JZ85UJPkVn6zwopYDQIGM=",
       "dev": true,
       "dependencies": {
-        "available-typed-arrays": "^1.0.5",
-        "call-bind": "^1.0.2",
+        "available-typed-arrays": "^1.0.7",
+        "call-bind": "^1.0.7",
         "for-each": "^0.3.3",
-        "has-proto": "^1.0.1",
-        "is-typed-array": "^1.1.10"
+        "gopd": "^1.0.1",
+        "has-proto": "^1.0.3",
+        "is-typed-array": "^1.1.13"
       },
       "engines": {
         "node": ">= 0.4"
@@ -6602,14 +6574,20 @@
       }
     },
     "node_modules/typed-array-length": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/typed-array-length/-/typed-array-length-1.0.4.tgz",
-      "integrity": "sha512-KjZypGq+I/H7HI5HlOoGHkWUUGq+Q0TPhQurLbyrVrvnKTBgzLhIJ7j6J/XTQOi0d1RjyZ0wdas8bKs2p0x3Ng==",
+      "version": "1.0.6",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/typed-array-length/-/typed-array-length-1.0.6.tgz",
+      "integrity": "sha1-VxVSB8duZKNFdILf3BydHTxMc6M=",
       "dev": true,
       "dependencies": {
-        "call-bind": "^1.0.2",
+        "call-bind": "^1.0.7",
         "for-each": "^0.3.3",
-        "is-typed-array": "^1.1.9"
+        "gopd": "^1.0.1",
+        "has-proto": "^1.0.3",
+        "is-typed-array": "^1.1.13",
+        "possible-typed-array-names": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -6617,8 +6595,8 @@
     },
     "node_modules/unbox-primitive": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.2.tgz",
-      "integrity": "sha512-61pPlCD9h51VoreyJ0BReideM3MDKMKnh6+V9L08331ipq6Q8OFXZYiqP6n/tbHx4s5I9uRhcye6BrbkizkBDw==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/unbox-primitive/-/unbox-primitive-1.0.2.tgz",
+      "integrity": "sha1-KQMgIQV9Xmzb0IxRKcIm3/jtb54=",
       "dev": true,
       "dependencies": {
         "call-bind": "^1.0.2",
@@ -6630,29 +6608,24 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/underscore": {
-      "version": "1.13.6",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.6.tgz",
-      "integrity": "sha512-+A5Sja4HP1M08MaXya7p5LvjuM7K6q/2EaC0+iovj/wOcMsTzMvDFbasi/oSapiwOlt252IqsKqPjCl7huKS0A=="
-    },
     "node_modules/undici-types": {
-      "version": "5.25.3",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.25.3.tgz",
-      "integrity": "sha512-Ga1jfYwRn7+cP9v8auvEXN1rX3sWqlayd4HP7OKk4mZWylEmu3KzXDUGrQUN6Ol7qo1gPvB2e5gX6udnyEPgdA==",
+      "version": "5.26.5",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha1-vNU5iT0AtW6WT9JlekhmsiGmVhc=",
       "dev": true
     },
     "node_modules/unpipe": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
-      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=",
       "engines": {
         "node": ">= 0.8"
       }
     },
     "node_modules/update-browserslist-db": {
-      "version": "1.0.13",
-      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.13.tgz",
-      "integrity": "sha512-xebP81SNcPuNpPP3uzeW1NYXxI3rxyJzF3pD6sH4jE7o/IX+WtSpwnVU+qIsDPyk0d3hmFQ7mjqc6AtV604hbg==",
+      "version": "1.0.16",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/update-browserslist-db/-/update-browserslist-db-1.0.16.tgz",
+      "integrity": "sha1-9tSJ7ZD7LwfWd4TrP1PXiR9zY1Y=",
       "dev": true,
       "funding": [
         {
@@ -6669,8 +6642,8 @@
         }
       ],
       "dependencies": {
-        "escalade": "^3.1.1",
-        "picocolors": "^1.0.0"
+        "escalade": "^3.1.2",
+        "picocolors": "^1.0.1"
       },
       "bin": {
         "update-browserslist-db": "cli.js"
@@ -6681,8 +6654,8 @@
     },
     "node_modules/uri-js": {
       "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
-      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha1-mxpSWVIlhZ5V9mnZKPiMbFfyp34=",
       "dev": true,
       "dependencies": {
         "punycode": "^2.1.0"
@@ -6690,30 +6663,29 @@
     },
     "node_modules/urix": {
       "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
-      "integrity": "sha512-Am1ousAhSLBeB9cG/7k7r2R0zj50uDRlZHPGbazid5s9rlF1F/QKYObEKSIunSjIOkJZqwRRLpvewjEkM7pSqg==",
-      "deprecated": "Please see https://github.com/lydell/urix#deprecated"
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/urix/-/urix-0.1.0.tgz",
+      "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI="
     },
     "node_modules/utils-merge": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
-      "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/utils-merge/-/utils-merge-1.0.1.tgz",
+      "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=",
       "engines": {
         "node": ">= 0.4.0"
       }
     },
     "node_modules/uuid": {
       "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha1-gNW1ztJxu5r2xEXyGhoExgbO++I=",
       "bin": {
         "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/v8-to-istanbul": {
-      "version": "9.1.3",
-      "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-9.1.3.tgz",
-      "integrity": "sha512-9lDD+EVI2fjFsMWXc6dy5JJzBsVTcQ2fVkfBvncZ6xJWG9wtBhOldG+mHkSL0+V1K/xgZz0JDO5UT5hFwHUghg==",
+      "version": "9.2.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/v8-to-istanbul/-/v8-to-istanbul-9.2.0.tgz",
+      "integrity": "sha1-LtdkSiRc3dg9Tgh7mzOz5i39EK0=",
       "dev": true,
       "dependencies": {
         "@jridgewell/trace-mapping": "^0.3.12",
@@ -6726,8 +6698,8 @@
     },
     "node_modules/vary": {
       "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
-      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=",
       "engines": {
         "node": ">= 0.8"
       }
@@ -6742,8 +6714,8 @@
     },
     "node_modules/walker": {
       "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/walker/-/walker-1.0.8.tgz",
-      "integrity": "sha512-ts/8E8l5b7kY0vlWLewOkDXMmPdLcVV4GmOQLyxuSswIJsweeFZtAsMF7k1Nszz+TYBQrlYRmzOnr398y1JemQ==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/walker/-/walker-1.0.8.tgz",
+      "integrity": "sha1-vUmNtHev5XPcBBhfAR06uKjXZT8=",
       "dev": true,
       "dependencies": {
         "makeerror": "1.0.12"
@@ -6751,8 +6723,8 @@
     },
     "node_modules/which": {
       "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
-      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/which/-/which-2.0.2.tgz",
+      "integrity": "sha1-fGqN0KY2oDJ+ELWckobu6T8/UbE=",
       "dev": true,
       "dependencies": {
         "isexe": "^2.0.0"
@@ -6766,8 +6738,8 @@
     },
     "node_modules/which-boxed-primitive": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.0.2.tgz",
-      "integrity": "sha512-bwZdv0AKLpplFY2KZRX6TvyuN7ojjr7lwkg6ml0roIy9YeuSr7JS372qlNW18UQYzgYK9ziGcerWqZOmEn9VNg==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/which-boxed-primitive/-/which-boxed-primitive-1.0.2.tgz",
+      "integrity": "sha1-E3V7yJsgmwSf5dhkMOIc9AqJqOY=",
       "dev": true,
       "dependencies": {
         "is-bigint": "^1.0.1",
@@ -6781,16 +6753,16 @@
       }
     },
     "node_modules/which-typed-array": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.11.tgz",
-      "integrity": "sha512-qe9UWWpkeG5yzZ0tNYxDmd7vo58HDBc39mZ0xWWpolAGADdFOzkfamWLDxkOWcvHQKVmdTyQdLD4NOfjLWTKew==",
+      "version": "1.1.15",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/which-typed-array/-/which-typed-array-1.1.15.tgz",
+      "integrity": "sha1-JkhZ6bEaZJs4i/qvT3Z98fd5s40=",
       "dev": true,
       "dependencies": {
-        "available-typed-arrays": "^1.0.5",
-        "call-bind": "^1.0.2",
+        "available-typed-arrays": "^1.0.7",
+        "call-bind": "^1.0.7",
         "for-each": "^0.3.3",
         "gopd": "^1.0.1",
-        "has-tostringtag": "^1.0.0"
+        "has-tostringtag": "^1.0.2"
       },
       "engines": {
         "node": ">= 0.4"
@@ -6813,10 +6785,19 @@
         "node": ">= 10.0.0"
       }
     },
+    "node_modules/word-wrap": {
+      "version": "1.2.5",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha1-0sRcbdT7zmIaZvE2y+Mor9BBCzQ=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/wrap-ansi": {
       "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
-      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha1-Z+FFz/UQpqaYS98RUpEdadLrnkM=",
       "dependencies": {
         "ansi-styles": "^4.0.0",
         "string-width": "^4.1.0",
@@ -6831,13 +6812,13 @@
     },
     "node_modules/wrappy": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
     },
     "node_modules/write-file-atomic": {
       "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-4.0.2.tgz",
-      "integrity": "sha512-7KxauUdBmSdWnmpaGFg+ppNjKF8uNLry8LyzjauQDOVONfFLNKrKvQOxZ/VuTIcS/gge/YNahf5RIIQWTSarlg==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/write-file-atomic/-/write-file-atomic-4.0.2.tgz",
+      "integrity": "sha1-qd8Brlt3hYoCf9LoB2juQzVV/P0=",
       "dev": true,
       "dependencies": {
         "imurmurhash": "^0.1.4",
@@ -6847,32 +6828,24 @@
         "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
     },
-    "node_modules/xpath.js": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/xpath.js/-/xpath.js-1.1.0.tgz",
-      "integrity": "sha512-jg+qkfS4K8E7965sqaUl8mRngXiKb3WZGfONgE18pr03FUQiuSV6G+Ej4tS55B+rIQSFEIw3phdVAQ4pPqNWfQ==",
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
     "node_modules/y18n": {
       "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
-      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha1-f0k00PfKjFb5UxSTndzS3ZHOHVU=",
       "engines": {
         "node": ">=10"
       }
     },
     "node_modules/yallist": {
       "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
-      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha1-27fa+b/YusmrRev2ArjLrQ1dCP0=",
       "dev": true
     },
     "node_modules/yargs": {
       "version": "17.7.2",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
-      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha1-mR3zmspnWhkrgW4eA2P5110qomk=",
       "dependencies": {
         "cliui": "^8.0.1",
         "escalade": "^3.1.1",
@@ -6888,16 +6861,16 @@
     },
     "node_modules/yargs-parser": {
       "version": "21.1.1",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
-      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha1-kJa87r+ZDSG7MfqVFuDt4pSnfTU=",
       "engines": {
         "node": ">=12"
       }
     },
     "node_modules/yocto-queue": {
       "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
-      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha1-ApTrPe4FAo0x7hpfosVWpqrxChs=",
       "dev": true,
       "engines": {
         "node": ">=10"

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "2.0.1",
       "license": "MIT",
       "dependencies": {
-        "jsonwebtoken": "^8.5.1",
+        "jsonwebtoken": "^9.0.2",
         "lodash": "^4.17.21",
         "login.dfe.async-retry": "github:DFE-Digital/login.dfe.async-retry#v2.0.3",
         "login.dfe.jwt-strategies": "github:DFE-Digital/login.dfe.jwt-strategies#v4.1.0",
@@ -4645,9 +4645,9 @@
       }
     },
     "node_modules/jsonwebtoken": {
-      "version": "8.5.1",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/jsonwebtoken/-/jsonwebtoken-8.5.1.tgz",
-      "integrity": "sha1-AOceC431TCEhofJhN98igGc7zA0=",
+      "version": "9.0.2",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/jsonwebtoken/-/jsonwebtoken-9.0.2.tgz",
+      "integrity": "sha1-Zf+R9KvvF4RpfUCVK7GZjFBMqvM=",
       "dependencies": {
         "jws": "^3.2.2",
         "lodash.includes": "^4.3.0",
@@ -4658,11 +4658,11 @@
         "lodash.isstring": "^4.0.1",
         "lodash.once": "^4.0.0",
         "ms": "^2.1.1",
-        "semver": "^5.6.0"
+        "semver": "^7.5.4"
       },
       "engines": {
-        "node": ">=4",
-        "npm": ">=1.4.28"
+        "node": ">=12",
+        "npm": ">=6"
       }
     },
     "node_modules/jsonwebtoken/node_modules/ms": {
@@ -4671,11 +4671,14 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
     },
     "node_modules/jsonwebtoken/node_modules/semver": {
-      "version": "5.7.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
-      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
+      "version": "7.6.2",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/semver/-/semver-7.6.2.tgz",
+      "integrity": "sha1-Hjs0dZ+Jbo8U1hNHMs55iusMbhM=",
       "bin": {
-        "semver": "bin/semver"
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/jstransformer": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,10 +11,9 @@
       "dependencies": {
         "jsonwebtoken": "^8.5.1",
         "lodash": "^4.17.21",
+        "login.dfe.async-retry": "github:DFE-Digital/login.dfe.async-retry#v2.0.3",
         "login.dfe.jwt-strategies": "github:DFE-Digital/login.dfe.jwt-strategies#v4.1.0",
         "login.dfe.kue": "github:DFE-Digital/login.dfe.kue#v0.12.0",
-        "request": "^2.88.2",
-        "request-promise": "^4.2.6",
         "uuid": "^8.3.2"
       },
       "devDependencies": {
@@ -1532,6 +1531,7 @@
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "dev": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -1611,18 +1611,6 @@
       },
       "engines": {
         "node": ">= 8"
-      }
-    },
-    "node_modules/apparatus": {
-      "version": "0.0.10",
-      "resolved": "https://registry.npmjs.org/apparatus/-/apparatus-0.0.10.tgz",
-      "integrity": "sha512-KLy/ugo33KZA7nugtQ7O0E1c8kQ52N3IvD/XgIh4w/Nr28ypfkwDfA67F1ev4N1m5D+BOk1+b2dEJDfpj/VvZg==",
-      "optional": true,
-      "dependencies": {
-        "sylvester": ">= 0.0.8"
-      },
-      "engines": {
-        "node": ">=0.2.6"
       }
     },
     "node_modules/argparse": {
@@ -1749,26 +1737,10 @@
       "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
       "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA=="
     },
-    "node_modules/asn1": {
-      "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.6.tgz",
-      "integrity": "sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==",
-      "dependencies": {
-        "safer-buffer": "~2.1.0"
-      }
-    },
     "node_modules/assert-never": {
       "version": "1.2.1",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/assert-never/-/assert-never-1.2.1.tgz",
       "integrity": "sha1-EfDjY78UYgX7CBk7XHuQ9NHPRP4="
-    },
-    "node_modules/assert-plus": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-      "integrity": "sha512-NfJ4UzBCcQGLDlQq7nHxH+tv3kyZ0hHQqF5BO6J7tNJeP5do1llPr8dZ8zHonfhAu0PHAdMkSo+8o0wxg9lZWw==",
-      "engines": {
-        "node": ">=0.8"
-      }
     },
     "node_modules/async": {
       "version": "2.6.4",
@@ -1777,11 +1749,6 @@
       "dependencies": {
         "lodash": "^4.17.14"
       }
-    },
-    "node_modules/asynckit": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
     },
     "node_modules/atob": {
       "version": "2.1.2",
@@ -1805,19 +1772,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/aws-sign2": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
-      "integrity": "sha512-08kcGqnYf/YmjoRhfxyu+CLxBjUtHLXLXX/vUfx9l2LYzG3c1m61nrpyFUZI6zeS+Li/wWMMidD9KgrqtGq3mA==",
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/aws4": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.12.0.tgz",
-      "integrity": "sha512-NmWvPnx0F1SfrQbYwOi7OeaNGokp9XhzNioJ/CSBs8Qa4vxug81mhJEAVZwxXuBmYB5KDRfMq/F3RR0BIU7sWg=="
     },
     "node_modules/axios": {
       "version": "0.21.4",
@@ -1949,19 +1903,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
-    },
-    "node_modules/bcrypt-pbkdf": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
-      "integrity": "sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==",
-      "dependencies": {
-        "tweetnacl": "^0.14.3"
-      }
-    },
-    "node_modules/bluebird": {
-      "version": "3.7.2",
-      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
-      "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg=="
     },
     "node_modules/body-parser": {
       "version": "1.20.2",
@@ -2117,11 +2058,6 @@
         }
       ]
     },
-    "node_modules/caseless": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-      "integrity": "sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw=="
-    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -2221,17 +2157,6 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
     },
-    "node_modules/combined-stream": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
-      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "dependencies": {
-        "delayed-stream": "~1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -2290,11 +2215,6 @@
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ=="
     },
-    "node_modules/core-util-is": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ=="
-    },
     "node_modules/create-jest": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/create-jest/-/create-jest-29.7.0.tgz",
@@ -2347,17 +2267,6 @@
       "integrity": "sha512-UNIFik2RgSbiTwIW1IsFwXWn6vs+bYdq83LKTSOsx7NJR7WII9dxewkHLltfTLVppoUApHV0118a4RZRI9FLwA==",
       "dependencies": {
         "css": "^2.0.0"
-      }
-    },
-    "node_modules/dashdash": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
-      "integrity": "sha512-jRFi8UDGo6j+odZiEpjazZaWqEal3w/basFjQHQEwVtZJGDpxbH1MeYluwCS8Xq5wmLJooDlMgvVarmWfGM44g==",
-      "dependencies": {
-        "assert-plus": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=0.10"
       }
     },
     "node_modules/date-utils": {
@@ -2444,14 +2353,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/delayed-stream": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
     "node_modules/denque": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/denque/-/denque-1.5.1.tgz",
@@ -2511,21 +2412,6 @@
       "version": "1.1.0",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/doctypes/-/doctypes-1.1.0.tgz",
       "integrity": "sha1-6oCxBqh1OHdOijpKWv4pPeSJ4Kk="
-    },
-    "node_modules/double-ended-queue": {
-      "version": "2.1.0-0",
-      "resolved": "https://registry.npmjs.org/double-ended-queue/-/double-ended-queue-2.1.0-0.tgz",
-      "integrity": "sha512-+BNfZ+deCo8hMNpDqDnvT+c0XpJ5cUa6mqYq89bho2Ifze4URTqRkcwR399hWoTrTkbZ/XJYDgP6rc7pRgffEQ==",
-      "optional": true
-    },
-    "node_modules/ecc-jsbn": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
-      "integrity": "sha512-eh9O+hwRHNbG4BLTjEl3nw044CkGm5X6LoaCf7LPp7UU8Qrt47JYNi6nPX8xjW97TKGKm1ouctg0QSpZe9qrnw==",
-      "dependencies": {
-        "jsbn": "~0.1.0",
-        "safer-buffer": "^2.1.0"
-      }
     },
     "node_modules/ecdsa-sig-formatter": {
       "version": "1.0.11",
@@ -3107,28 +2993,17 @@
         "node": ">= 0.10.0"
       }
     },
-    "node_modules/extend": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
-    },
-    "node_modules/extsprintf": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
-      "integrity": "sha512-11Ndz7Nv+mvAC1j0ktTa7fAb0vLyGGX+rMHNBYQviQDGU0Hw7lhctJANqbPhu9nV9/izT/IntTgZ7Im/9LJs9g==",
-      "engines": [
-        "node >=0.6.0"
-      ]
-    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true
     },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
-      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true
     },
     "node_modules/fast-levenshtein": {
       "version": "2.0.6",
@@ -3257,14 +3132,6 @@
       "dev": true,
       "dependencies": {
         "is-callable": "^1.1.3"
-      }
-    },
-    "node_modules/forever-agent": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-      "integrity": "sha512-j0KLYPhm6zeac4lz3oJ3o65qvgQCcPubiyotZrXqEaG4hNagNYO8qdlUrX5vwqv9ohqeT/Z3j6+yW067yWWdUw==",
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/forwarded": {
@@ -3405,14 +3272,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/getpass": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
-      "integrity": "sha512-0fzj9JxOLfJ+XGLhR8ze3unN0KZCgZwiSSDz168VERjK8Wl8kVSdcu2kspd4s4wtAa1y/qrVRiAA0WclVsu0ng==",
-      "dependencies": {
-        "assert-plus": "^1.0.0"
-      }
-    },
     "node_modules/glob": {
       "version": "7.2.3",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
@@ -3497,27 +3356,6 @@
       "resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
       "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
       "dev": true
-    },
-    "node_modules/har-schema": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
-      "integrity": "sha512-Oqluz6zhGX8cyRaTQlFMPw80bSJVG2x/cFb8ZPhUILGgHka9SsokCCOQgpveePerqidZOrT14ipqfJb7ILcW5Q==",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/har-validator": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.5.tgz",
-      "integrity": "sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==",
-      "deprecated": "this library is no longer supported",
-      "dependencies": {
-        "ajv": "^6.12.3",
-        "har-schema": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
     },
     "node_modules/has": {
       "version": "1.0.4",
@@ -3612,20 +3450,6 @@
       },
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/http-signature": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
-      "integrity": "sha512-CAbnr6Rz4CYQkLYUtSNXxQPUH2gK8f3iWexVlsnMeD+GjlsQ0Xsy1cOX+mN3dtxYomRy21CiOzU8Uhw6OwncEQ==",
-      "dependencies": {
-        "assert-plus": "^1.0.0",
-        "jsprim": "^1.2.2",
-        "sshpk": "^1.7.0"
-      },
-      "engines": {
-        "node": ">=0.8",
-        "npm": ">=1.3.7"
       }
     },
     "node_modules/human-signals": {
@@ -4015,11 +3839,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/is-typedarray": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-      "integrity": "sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA=="
-    },
     "node_modules/is-weakref": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.0.2.tgz",
@@ -4043,11 +3862,6 @@
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true
-    },
-    "node_modules/isstream": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-      "integrity": "sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g=="
     },
     "node_modules/istanbul-lib-coverage": {
       "version": "3.2.0",
@@ -4782,11 +4596,6 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
-    "node_modules/jsbn": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-      "integrity": "sha512-UVU9dibq2JcFWxQPA6KCqj5O42VOmAY3zQUfEKxU0KpTGXwNoCjkX1e13eHNvw/xPynt6pU0rZ1htjWTNTSXsg=="
-    },
     "node_modules/jsesc": {
       "version": "2.5.2",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
@@ -4811,26 +4620,17 @@
       "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
       "dev": true
     },
-    "node_modules/json-schema": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
-      "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA=="
-    },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true
     },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
       "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
       "dev": true
-    },
-    "node_modules/json-stringify-safe": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-      "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA=="
     },
     "node_modules/json5": {
       "version": "2.2.3",
@@ -4876,20 +4676,6 @@
       "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
       "bin": {
         "semver": "bin/semver"
-      }
-    },
-    "node_modules/jsprim": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.2.tgz",
-      "integrity": "sha512-P2bSOMAc/ciLz6DzgjVlGJP9+BrJWu5UDGK70C2iweC5QBIeFf0ZXRvGjEj2uYgrY2MkAAhsSWHDWlFtEroZWw==",
-      "dependencies": {
-        "assert-plus": "1.0.0",
-        "extsprintf": "1.3.0",
-        "json-schema": "0.4.0",
-        "verror": "1.10.0"
-      },
-      "engines": {
-        "node": ">=0.6.0"
       }
     },
     "node_modules/jstransformer": {
@@ -5027,6 +4813,13 @@
       "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
       "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg=="
     },
+    "node_modules/login.dfe.async-retry": {
+      "version": "2.0.3",
+      "resolved": "git+ssh://git@github.com/DFE-Digital/login.dfe.async-retry.git#72c42369276361f6cdeaabc331100f50b4a10dbf",
+      "dependencies": {
+        "retry": "^0.13.1"
+      }
+    },
     "node_modules/login.dfe.jwt-strategies": {
       "version": "1.1.0",
       "resolved": "git+ssh://git@github.com/DFE-Digital/login.dfe.jwt-strategies.git#7e2c363a5acf922e04774c7ff6317e7c2697c7f3",
@@ -5038,9 +4831,8 @@
     },
     "node_modules/login.dfe.kue": {
       "name": "kue",
-      "version": "0.11.6",
-      "resolved": "git+ssh://git@github.com/DFE-Digital/login.dfe.kue.git#34b29db0b31364ac932c21dffa3eeaf8607c55f3",
-      "license": "MIT",
+      "version": "0.12.0",
+      "resolved": "git+ssh://git@github.com/DFE-Digital/login.dfe.kue.git#debef8bae8e67cce4a42fee4be23a4f6bf3b7ce4",
       "dependencies": {
         "body-parser": "^1.12.2",
         "express": "^4.12.2",
@@ -5054,9 +4846,6 @@
       },
       "bin": {
         "kue-dashboard": "bin/kue-dashboard"
-      },
-      "optionalDependencies": {
-        "reds": "^1.0.0"
       }
     },
     "node_modules/lru-cache": {
@@ -5244,20 +5033,6 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
     },
-    "node_modules/natural": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/natural/-/natural-0.5.0.tgz",
-      "integrity": "sha512-gkf5ZZD5+jZ+9Vv/xJLhyYwAA2xHiLyL6sb1Pm4xJkIk9GyCRIBQfM+Np+CjH0xdLTapLkI9cccfuJbk1+UjJQ==",
-      "optional": true,
-      "dependencies": {
-        "apparatus": ">= 0.0.9",
-        "sylvester": ">= 0.0.12",
-        "underscore": ">=1.3.1"
-      },
-      "engines": {
-        "node": ">=0.4.10"
-      }
-    },
     "node_modules/natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
@@ -5395,14 +5170,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/oauth-sign": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
-      "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/object-assign": {
@@ -5672,11 +5439,6 @@
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
       "integrity": "sha512-5DFkuoqlv1uYQKxy8omFBeJPQcdoE07Kv2sferDCrAq1ohOU+MSDswDIbnx3YAM60qIOnYa53wBhXW0EbMonrQ=="
     },
-    "node_modules/performance-now": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-      "integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow=="
-    },
     "node_modules/picocolors": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
@@ -5836,11 +5598,6 @@
         "node": ">= 0.10"
       }
     },
-    "node_modules/psl": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/psl/-/psl-1.9.0.tgz",
-      "integrity": "sha512-E/ZsdU4HLs/68gYzgGTkMicWTLPdAftJLfJFlLUAAKZGkStNU72sZjT66SnMDVOfOWY/YAoiD7Jxa9iHvngcag=="
-    },
     "node_modules/pug": {
       "version": "3.0.3",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/pug/-/pug-3.0.3.tgz",
@@ -5957,6 +5714,7 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.0.tgz",
       "integrity": "sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA==",
+      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -6081,39 +5839,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/reds": {
-      "version": "1.0.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/reds/-/reds-1.0.0.tgz",
-      "integrity": "sha1-6W2zYagwLLHnXSF6AzKqtrmOH6g=",
-      "optional": true,
-      "dependencies": {
-        "natural": "0.5.0",
-        "redis": "^2.7.1"
-      }
-    },
-    "node_modules/reds/node_modules/redis": {
-      "version": "2.8.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/redis/-/redis-2.8.0.tgz",
-      "integrity": "sha1-ICKI4/WMSfYHnZevehDhMDrhSwI=",
-      "optional": true,
-      "dependencies": {
-        "double-ended-queue": "^2.1.0-0",
-        "redis-commands": "^1.2.0",
-        "redis-parser": "^2.6.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/reds/node_modules/redis-parser": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-2.6.0.tgz",
-      "integrity": "sha512-9Hdw19gwXFBJdN8ENUoNVJFRyMDFrE/ZBClPicKYDPwNPJ4ST1TedAHYNSiGKElwh2vrmRGMoJYbVdJd+WQXIw==",
-      "optional": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/regexp.prototype.flags": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.1.tgz",
@@ -6129,97 +5854,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/request": {
-      "version": "2.88.2",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/request/-/request-2.88.2.tgz",
-      "integrity": "sha1-1zyRhzHLWofaBH4gcjQUb2ZNErM=",
-      "dependencies": {
-        "aws-sign2": "~0.7.0",
-        "aws4": "^1.8.0",
-        "caseless": "~0.12.0",
-        "combined-stream": "~1.0.6",
-        "extend": "~3.0.2",
-        "forever-agent": "~0.6.1",
-        "form-data": "~2.3.2",
-        "har-validator": "~5.1.3",
-        "http-signature": "~1.2.0",
-        "is-typedarray": "~1.0.0",
-        "isstream": "~0.1.2",
-        "json-stringify-safe": "~5.0.1",
-        "mime-types": "~2.1.19",
-        "oauth-sign": "~0.9.0",
-        "performance-now": "^2.1.0",
-        "qs": "~6.5.2",
-        "safe-buffer": "^5.1.2",
-        "tough-cookie": "~2.5.0",
-        "tunnel-agent": "^0.6.0",
-        "uuid": "^3.3.2"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/request-promise": {
-      "version": "4.2.6",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/request-promise/-/request-promise-4.2.6.tgz",
-      "integrity": "sha1-fn5blXhjDm9ZjjgTwPjrNCon8KI=",
-      "dependencies": {
-        "bluebird": "^3.5.0",
-        "request-promise-core": "1.1.4",
-        "stealthy-require": "^1.1.1",
-        "tough-cookie": "^2.3.3"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      },
-      "peerDependencies": {
-        "request": "^2.34"
-      }
-    },
-    "node_modules/request-promise-core": {
-      "version": "1.1.4",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/request-promise-core/-/request-promise-core-1.1.4.tgz",
-      "integrity": "sha1-Pu3UIjII1BmGe3jOgVFn0QWToi8=",
-      "dependencies": {
-        "lodash": "^4.17.19"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      },
-      "peerDependencies": {
-        "request": "^2.34"
-      }
-    },
-    "node_modules/request/node_modules/form-data": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
-      "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
-      "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.6",
-        "mime-types": "^2.1.12"
-      },
-      "engines": {
-        "node": ">= 0.12"
-      }
-    },
-    "node_modules/request/node_modules/qs": {
-      "version": "6.5.3",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.3.tgz",
-      "integrity": "sha512-qxXIEh4pCGfHICj1mAJQ2/2XVZkjCDTcEgfoSQxc/fYivUZxTkk7L3bDBJSoNrEzXI17oUO5Dp07ktqE5KzczA==",
-      "engines": {
-        "node": ">=0.6"
-      }
-    },
-    "node_modules/request/node_modules/uuid": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
-      "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
-      "bin": {
-        "uuid": "bin/uuid"
       }
     },
     "node_modules/require-directory": {
@@ -6289,6 +5923,14 @@
       "dev": true,
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/retry": {
+      "version": "0.13.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/retry/-/retry-0.13.1.tgz",
+      "integrity": "sha1-GFsVh6z2eRnWOzVzSeA1N7JIRlg=",
+      "engines": {
+        "node": ">= 4"
       }
     },
     "node_modules/reusify": {
@@ -6567,30 +6209,6 @@
       "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
       "dev": true
     },
-    "node_modules/sshpk": {
-      "version": "1.17.0",
-      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.17.0.tgz",
-      "integrity": "sha512-/9HIEs1ZXGhSPE8X6Ccm7Nam1z8KcoCqPdI7ecm1N33EzAetWahvQWVqLZtaZQ+IDKX4IyA2o0gBzqIMkAagHQ==",
-      "dependencies": {
-        "asn1": "~0.2.3",
-        "assert-plus": "^1.0.0",
-        "bcrypt-pbkdf": "^1.0.0",
-        "dashdash": "^1.12.0",
-        "ecc-jsbn": "~0.1.1",
-        "getpass": "^0.1.1",
-        "jsbn": "~0.1.0",
-        "safer-buffer": "^2.0.2",
-        "tweetnacl": "~0.14.0"
-      },
-      "bin": {
-        "sshpk-conv": "bin/sshpk-conv",
-        "sshpk-sign": "bin/sshpk-sign",
-        "sshpk-verify": "bin/sshpk-verify"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/stack-utils": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.6.tgz",
@@ -6618,14 +6236,6 @@
       "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/stealthy-require": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
-      "integrity": "sha512-ZnWpYnYugiOVEY5GkcuJK1io5V8QmNYChG62gSit9pQVGErXtrKuPC55ITaVSukmMta5qpMU7vqLt2Lnni4f/g==",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/string-length": {
@@ -6800,15 +6410,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/sylvester": {
-      "version": "0.0.21",
-      "resolved": "https://registry.npmjs.org/sylvester/-/sylvester-0.0.21.tgz",
-      "integrity": "sha512-yUT0ukFkFEt4nb+NY+n2ag51aS/u9UHXoZw+A4jgD77/jzZsBoSDHuqysrVCBC4CYR4TYvUJq54ONpXgDBH8tA==",
-      "optional": true,
-      "engines": {
-        "node": ">=0.2.6"
-      }
-    },
     "node_modules/test-exclude": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-6.0.0.tgz",
@@ -6868,18 +6469,6 @@
       "resolved": "https://registry.npmjs.org/token-stream/-/token-stream-1.0.0.tgz",
       "integrity": "sha512-VSsyNPPW74RpHwR8Fc21uubwHY7wMDeJLys2IX5zJNih+OnAnaifKHo+1LHT7DAdloQ7apeaaWg8l7qnf/TnEg=="
     },
-    "node_modules/tough-cookie": {
-      "version": "2.5.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/tough-cookie/-/tough-cookie-2.5.0.tgz",
-      "integrity": "sha1-zZ+yoKodWhK0c72fuW+j3P9lreI=",
-      "dependencies": {
-        "psl": "^1.1.28",
-        "punycode": "^2.1.1"
-      },
-      "engines": {
-        "node": ">=0.8"
-      }
-    },
     "node_modules/tsconfig-paths": {
       "version": "3.14.2",
       "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.14.2.tgz",
@@ -6912,22 +6501,6 @@
       "engines": {
         "node": ">=4"
       }
-    },
-    "node_modules/tunnel-agent": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
-      "dependencies": {
-        "safe-buffer": "^5.0.1"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/tweetnacl": {
-      "version": "0.14.5",
-      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-      "integrity": "sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA=="
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -7107,6 +6680,7 @@
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
       "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
       "dependencies": {
         "punycode": "^2.1.0"
       }
@@ -7153,19 +6727,6 @@
       "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/verror": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
-      "integrity": "sha512-ZZKSmDAEFOijERBLkmYfJ+vmk3w+7hOLYDNkRCuRuMJGEmqYNCNLyBBFwWKVMhfwaEF3WOd0Zlw86U/WC/+nYw==",
-      "engines": [
-        "node >=0.6.0"
-      ],
-      "dependencies": {
-        "assert-plus": "^1.0.0",
-        "core-util-is": "1.0.2",
-        "extsprintf": "^1.2.0"
       }
     },
     "node_modules/void-elements": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "jsonwebtoken": "^8.5.1",
         "lodash": "^4.17.21",
-        "login.dfe.jwt-strategies": "git+https://github.com/DFE-Digital/login.dfe.jwt-strategies.git#v3.0",
+        "login.dfe.jwt-strategies": "git+https://github.com/DFE-Digital/login.dfe.jwt-strategies.git#v4.0.0",
         "login.dfe.kue": "git+https://github.com/DFE-Digital/login.dfe.kue.git#v0.11.6",
         "request": "^2.88.2",
         "request-promise": "^4.2.6",
@@ -1759,8 +1759,8 @@
     },
     "node_modules/assert-never": {
       "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/assert-never/-/assert-never-1.2.1.tgz",
-      "integrity": "sha512-TaTivMB6pYI1kXwrFlEhLeGfOqoDNdTxjCdwRfFFkEA30Eu+k48W34nlok2EYWJfFFzqaEmichdNM7th6M5HNw=="
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/assert-never/-/assert-never-1.2.1.tgz",
+      "integrity": "sha1-EfDjY78UYgX7CBk7XHuQ9NHPRP4="
     },
     "node_modules/assert-plus": {
       "version": "1.0.0",
@@ -1821,8 +1821,8 @@
     },
     "node_modules/axios": {
       "version": "0.21.4",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
-      "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/axios/-/axios-0.21.4.tgz",
+      "integrity": "sha1-xnuQ3AVo5cHPKwuFjEO6KOLtpXU=",
       "dependencies": {
         "follow-redirects": "^1.14.0"
       }
@@ -1936,8 +1936,8 @@
     },
     "node_modules/babel-walk": {
       "version": "3.0.0-canary-5",
-      "resolved": "https://registry.npmjs.org/babel-walk/-/babel-walk-3.0.0-canary-5.tgz",
-      "integrity": "sha512-GAwkz0AihzY5bkwIY5QDR+LvsRQgB/B+1foMPvi0FZPMl5fjD7ICiznUiBdLYMH1QYe6vqu4gWYytZOccLouFw==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/babel-walk/-/babel-walk-3.0.0-canary-5.tgz",
+      "integrity": "sha1-9m7Ncpg1eu5ElV8jWm71QhkQSxE=",
       "dependencies": {
         "@babel/types": "^7.9.6"
       },
@@ -2278,9 +2278,9 @@
       "dev": true
     },
     "node_modules/cookie": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
-      "integrity": "sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==",
+      "version": "0.6.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/cookie/-/cookie-0.6.0.tgz",
+      "integrity": "sha1-J5iwSwcbDsv/DbtipQWo76ThkFE=",
       "engines": {
         "node": ">= 0.6"
       }
@@ -2509,8 +2509,8 @@
     },
     "node_modules/doctypes": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/doctypes/-/doctypes-1.1.0.tgz",
-      "integrity": "sha512-LLBi6pEqS6Do3EKQ3J0NqHWV5hhb78Pi8vvESYwyOy2c31ZEZVdtitdzsQsKb7878PEERhzUk0ftqGhG6Mz+pQ=="
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/doctypes/-/doctypes-1.1.0.tgz",
+      "integrity": "sha1-6oCxBqh1OHdOijpKWv4pPeSJ4Kk="
     },
     "node_modules/double-ended-queue": {
       "version": "2.1.0-0",
@@ -3067,16 +3067,16 @@
       }
     },
     "node_modules/express": {
-      "version": "4.18.2",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.18.2.tgz",
-      "integrity": "sha512-5/PsL6iGPdfQ/lKM1UuielYgv3BUoJfz1aUwU9vHZ+J7gyvwdQXFEBIEIaxeGf0GIcreATNyBExtalisDbuMqQ==",
+      "version": "4.19.2",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/express/-/express-4.19.2.tgz",
+      "integrity": "sha1-4lQ3gno6p/KoJ7yBcbu7Zko1ZGU=",
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
-        "body-parser": "1.20.1",
+        "body-parser": "1.20.2",
         "content-disposition": "0.5.4",
         "content-type": "~1.0.4",
-        "cookie": "0.5.0",
+        "cookie": "0.6.0",
         "cookie-signature": "1.0.6",
         "debug": "2.6.9",
         "depd": "2.0.0",
@@ -3105,43 +3105,6 @@
       },
       "engines": {
         "node": ">= 0.10.0"
-      }
-    },
-    "node_modules/express/node_modules/body-parser": {
-      "version": "1.20.1",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.1.tgz",
-      "integrity": "sha512-jWi7abTbYwajOytWCQc37VulmWiRae5RyTpaCyDcS5/lMdtwSz5lOpDE67srw/HYe35f1z3fDQw+3txg7gNtWw==",
-      "dependencies": {
-        "bytes": "3.1.2",
-        "content-type": "~1.0.4",
-        "debug": "2.6.9",
-        "depd": "2.0.0",
-        "destroy": "1.2.0",
-        "http-errors": "2.0.0",
-        "iconv-lite": "0.4.24",
-        "on-finished": "2.4.1",
-        "qs": "6.11.0",
-        "raw-body": "2.5.1",
-        "type-is": "~1.6.18",
-        "unpipe": "1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.8",
-        "npm": "1.2.8000 || >= 1.4.16"
-      }
-    },
-    "node_modules/express/node_modules/raw-body": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.1.tgz",
-      "integrity": "sha512-qqJBtEyVgS0ZmPGdCFPWJ3FreoqvG4MVQln/kCgF7Olq95IbOp0/BWyMwbdtn4VTvkM8Y7khCQ2Xgk/tcrCXig==",
-      "dependencies": {
-        "bytes": "3.1.2",
-        "http-errors": "2.0.0",
-        "iconv-lite": "0.4.24",
-        "unpipe": "1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.8"
       }
     },
     "node_modules/extend": {
@@ -3269,9 +3232,9 @@
       "dev": true
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.3",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.3.tgz",
-      "integrity": "sha512-1VzOtuEM8pC9SFU1E+8KfTjZyMztRsgEfwQl44z8A25uy13jSzTj6dyK2Df52iV0vgHCfBwLhDWevLn95w5v6Q==",
+      "version": "1.15.6",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/follow-redirects/-/follow-redirects-1.15.6.tgz",
+      "integrity": "sha1-f4FcDNpCScdP8J6V75fCO1/QOZs=",
       "funding": [
         {
           "type": "individual",
@@ -4798,8 +4761,8 @@
     },
     "node_modules/js-stringify": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/js-stringify/-/js-stringify-1.0.2.tgz",
-      "integrity": "sha512-rtS5ATOo2Q5k1G+DADISilDA6lv79zIiwFd6CcjuIxGKLFm5C+RLImRscVap9k55i+MOZwgliw+NejvkLuGD5g=="
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/js-stringify/-/js-stringify-1.0.2.tgz",
+      "integrity": "sha1-Fzb939lyTyijaCrcYjCufk6Weds="
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",
@@ -4883,8 +4846,8 @@
     },
     "node_modules/jsonwebtoken": {
       "version": "8.5.1",
-      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-8.5.1.tgz",
-      "integrity": "sha512-XjwVfRS6jTMsqYs0EsuJ4LGxXV14zQybNd4L2r0UvbVnSF9Af8x7p5MzbJ90Ioz/9TI41/hTCvznF/loiSzn8w==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/jsonwebtoken/-/jsonwebtoken-8.5.1.tgz",
+      "integrity": "sha1-AOceC431TCEhofJhN98igGc7zA0=",
       "dependencies": {
         "jws": "^3.2.2",
         "lodash.includes": "^4.3.0",
@@ -5879,11 +5842,11 @@
       "integrity": "sha512-E/ZsdU4HLs/68gYzgGTkMicWTLPdAftJLfJFlLUAAKZGkStNU72sZjT66SnMDVOfOWY/YAoiD7Jxa9iHvngcag=="
     },
     "node_modules/pug": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/pug/-/pug-3.0.2.tgz",
-      "integrity": "sha512-bp0I/hiK1D1vChHh6EfDxtndHji55XP/ZJKwsRqrz6lRia6ZC2OZbdAymlxdVFwd1L70ebrVJw4/eZ79skrIaw==",
+      "version": "3.0.3",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/pug/-/pug-3.0.3.tgz",
+      "integrity": "sha1-4YMkoxTNAiiDseA3K4rzoamfdZc=",
       "dependencies": {
-        "pug-code-gen": "^3.0.2",
+        "pug-code-gen": "^3.0.3",
         "pug-filters": "^4.0.0",
         "pug-lexer": "^5.0.1",
         "pug-linker": "^4.0.0",
@@ -5895,8 +5858,8 @@
     },
     "node_modules/pug-attrs": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/pug-attrs/-/pug-attrs-3.0.0.tgz",
-      "integrity": "sha512-azINV9dUtzPMFQktvTXciNAfAuVh/L/JCl0vtPCwvOA21uZrC08K/UnmrL+SXGEVc1FwzjW62+xw5S/uaLj6cA==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/pug-attrs/-/pug-attrs-3.0.0.tgz",
+      "integrity": "sha1-sQRR4DSBZeMfrRzCPr3dncc0fEE=",
       "dependencies": {
         "constantinople": "^4.0.1",
         "js-stringify": "^1.0.2",
@@ -5904,24 +5867,24 @@
       }
     },
     "node_modules/pug-code-gen": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/pug-code-gen/-/pug-code-gen-3.0.2.tgz",
-      "integrity": "sha512-nJMhW16MbiGRiyR4miDTQMRWDgKplnHyeLvioEJYbk1RsPI3FuA3saEP8uwnTb2nTJEKBU90NFVWJBk4OU5qyg==",
+      "version": "3.0.3",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/pug-code-gen/-/pug-code-gen-3.0.3.tgz",
+      "integrity": "sha1-WBMxeMtCP+Fxauzhwdo5KnUlFSA=",
       "dependencies": {
         "constantinople": "^4.0.1",
         "doctypes": "^1.1.0",
         "js-stringify": "^1.0.2",
         "pug-attrs": "^3.0.0",
-        "pug-error": "^2.0.0",
-        "pug-runtime": "^3.0.0",
+        "pug-error": "^2.1.0",
+        "pug-runtime": "^3.0.1",
         "void-elements": "^3.1.0",
         "with": "^7.0.0"
       }
     },
     "node_modules/pug-error": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/pug-error/-/pug-error-2.0.0.tgz",
-      "integrity": "sha512-sjiUsi9M4RAGHktC1drQfCr5C5eriu24Lfbt4s+7SykztEOwVZtbFk1RRq0tzLxcMxMYTBR+zMQaG07J/btayQ=="
+      "version": "2.1.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/pug-error/-/pug-error-2.1.0.tgz",
+      "integrity": "sha1-F+o3tYe2RD1LjxSDdOwntUtAblU="
     },
     "node_modules/pug-filters": {
       "version": "4.0.0",
@@ -5974,8 +5937,8 @@
     },
     "node_modules/pug-runtime": {
       "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/pug-runtime/-/pug-runtime-3.0.1.tgz",
-      "integrity": "sha512-L50zbvrQ35TkpHwv0G6aLSuueDRwc/97XdY8kL3tOT0FmhgG7UypU3VztfV/LATAvmUfYi4wNxSajhSAeNN+Kg=="
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/pug-runtime/-/pug-runtime-3.0.1.tgz",
+      "integrity": "sha1-9jaXYgRyPzWoxfb61qzaKhkbg9c="
     },
     "node_modules/pug-strip-comments": {
       "version": "2.0.0",
@@ -6120,8 +6083,8 @@
     },
     "node_modules/reds": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/reds/-/reds-1.0.0.tgz",
-      "integrity": "sha512-Aq+8pBhJQwGW2AzH7wA+Gzm05t0hGmkipDutgoZzlrH+B9OORQm4DZcX64A6thJQF+AX1l6PxR3mSf4gPOZskQ==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/reds/-/reds-1.0.0.tgz",
+      "integrity": "sha1-6W2zYagwLLHnXSF6AzKqtrmOH6g=",
       "optional": true,
       "dependencies": {
         "natural": "0.5.0",
@@ -6130,8 +6093,8 @@
     },
     "node_modules/reds/node_modules/redis": {
       "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/redis/-/redis-2.8.0.tgz",
-      "integrity": "sha512-M1OkonEQwtRmZv4tEWF2VgpG0JWJ8Fv1PhlgT5+B+uNq2cA3Rt1Yt/ryoR+vQNOQcIEgdCdfH0jr3bDpihAw1A==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/redis/-/redis-2.8.0.tgz",
+      "integrity": "sha1-ICKI4/WMSfYHnZevehDhMDrhSwI=",
       "optional": true,
       "dependencies": {
         "double-ended-queue": "^2.1.0-0",
@@ -6170,9 +6133,8 @@
     },
     "node_modules/request": {
       "version": "2.88.2",
-      "resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
-      "integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
-      "deprecated": "request has been deprecated, see https://github.com/request/request/issues/3142",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/request/-/request-2.88.2.tgz",
+      "integrity": "sha1-1zyRhzHLWofaBH4gcjQUb2ZNErM=",
       "dependencies": {
         "aws-sign2": "~0.7.0",
         "aws4": "^1.8.0",
@@ -6201,9 +6163,8 @@
     },
     "node_modules/request-promise": {
       "version": "4.2.6",
-      "resolved": "https://registry.npmjs.org/request-promise/-/request-promise-4.2.6.tgz",
-      "integrity": "sha512-HCHI3DJJUakkOr8fNoCc73E5nU5bqITjOYFMDrKHYOXWXrgD/SBaC7LjwuPymUprRyuF06UK7hd/lMHkmUXglQ==",
-      "deprecated": "request-promise has been deprecated because it extends the now deprecated request package, see https://github.com/request/request/issues/3142",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/request-promise/-/request-promise-4.2.6.tgz",
+      "integrity": "sha1-fn5blXhjDm9ZjjgTwPjrNCon8KI=",
       "dependencies": {
         "bluebird": "^3.5.0",
         "request-promise-core": "1.1.4",
@@ -6219,8 +6180,8 @@
     },
     "node_modules/request-promise-core": {
       "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.4.tgz",
-      "integrity": "sha512-TTbAfBBRdWD7aNNOoVOBH4pN/KigV6LyapYNNlAPA8JwbovRti1E88m3sYAwsLi5ryhPKsE9APwnjFTgdUjTpw==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/request-promise-core/-/request-promise-core-1.1.4.tgz",
+      "integrity": "sha1-Pu3UIjII1BmGe3jOgVFn0QWToi8=",
       "dependencies": {
         "lodash": "^4.17.19"
       },
@@ -6229,18 +6190,6 @@
       },
       "peerDependencies": {
         "request": "^2.34"
-      }
-    },
-    "node_modules/request-promise/node_modules/tough-cookie": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
-      "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
-      "dependencies": {
-        "psl": "^1.1.28",
-        "punycode": "^2.1.1"
-      },
-      "engines": {
-        "node": ">=0.8"
       }
     },
     "node_modules/request/node_modules/form-data": {
@@ -6262,18 +6211,6 @@
       "integrity": "sha512-qxXIEh4pCGfHICj1mAJQ2/2XVZkjCDTcEgfoSQxc/fYivUZxTkk7L3bDBJSoNrEzXI17oUO5Dp07ktqE5KzczA==",
       "engines": {
         "node": ">=0.6"
-      }
-    },
-    "node_modules/request/node_modules/tough-cookie": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
-      "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
-      "dependencies": {
-        "psl": "^1.1.28",
-        "punycode": "^2.1.1"
-      },
-      "engines": {
-        "node": ">=0.8"
       }
     },
     "node_modules/request/node_modules/uuid": {
@@ -6931,6 +6868,18 @@
       "resolved": "https://registry.npmjs.org/token-stream/-/token-stream-1.0.0.tgz",
       "integrity": "sha512-VSsyNPPW74RpHwR8Fc21uubwHY7wMDeJLys2IX5zJNih+OnAnaifKHo+1LHT7DAdloQ7apeaaWg8l7qnf/TnEg=="
     },
+    "node_modules/tough-cookie": {
+      "version": "2.5.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/tough-cookie/-/tough-cookie-2.5.0.tgz",
+      "integrity": "sha1-zZ+yoKodWhK0c72fuW+j3P9lreI=",
+      "dependencies": {
+        "psl": "^1.1.28",
+        "punycode": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/tsconfig-paths": {
       "version": "3.14.2",
       "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.14.2.tgz",
@@ -7221,8 +7170,8 @@
     },
     "node_modules/void-elements": {
       "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/void-elements/-/void-elements-3.1.0.tgz",
-      "integrity": "sha512-Dhxzh5HZuiHQhbvTW9AMetFfBHDMYpo23Uo9btPXgdYP+3T5S+p+jgNy7spra+veYhBP2dCSgxR/i2Y02h5/6w==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/void-elements/-/void-elements-3.1.0.tgz",
+      "integrity": "sha1-YU9/v42AHwu18GYfWy9XhXUOTwk=",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -7288,8 +7237,8 @@
     },
     "node_modules/with": {
       "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/with/-/with-7.0.2.tgz",
-      "integrity": "sha512-RNGKj82nUPg3g5ygxkQl0R937xLyho1J24ItRCBTr/m1YnZkzJy1hUiHUJrc/VlsDQzsCnInEGSg3bci0Lmd4w==",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/with/-/with-7.0.2.tgz",
+      "integrity": "sha1-zO461ULSVTinp6gKrSErmChJW6w=",
       "dependencies": {
         "@babel/parser": "^7.9.6",
         "@babel/types": "^7.9.6",

--- a/package.json
+++ b/package.json
@@ -19,8 +19,8 @@
   "dependencies": {
     "jsonwebtoken": "^8.5.1",
     "lodash": "^4.17.21",
-    "login.dfe.kue": "git+https://github.com/DFE-Digital/login.dfe.kue.git#v0.11.6",
-    "login.dfe.jwt-strategies": "git+https://github.com/DFE-Digital/login.dfe.jwt-strategies.git#v4.0.0",
+    "login.dfe.kue": "github:DFE-Digital/login.dfe.kue#v0.12.0",
+    "login.dfe.jwt-strategies": "github:DFE-Digital/login.dfe.jwt-strategies#v4.1.0",
     "request": "^2.88.2",
     "request-promise": "^4.2.6",
     "uuid": "^8.3.2"

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "homepage": "https://github.com/DFE-Digital/login.dfe.public-api.jobs#readme",
   "dependencies": {
-    "jsonwebtoken": "^8.5.1",
+    "jsonwebtoken": "^9.0.2",
     "lodash": "^4.17.21",
     "login.dfe.async-retry": "github:DFE-Digital/login.dfe.async-retry#v2.0.3",
     "login.dfe.jwt-strategies": "github:DFE-Digital/login.dfe.jwt-strategies#v4.1.0",

--- a/package.json
+++ b/package.json
@@ -19,10 +19,9 @@
   "dependencies": {
     "jsonwebtoken": "^8.5.1",
     "lodash": "^4.17.21",
-    "login.dfe.kue": "github:DFE-Digital/login.dfe.kue#v0.12.0",
+    "login.dfe.async-retry": "github:DFE-Digital/login.dfe.async-retry#v2.0.3",
     "login.dfe.jwt-strategies": "github:DFE-Digital/login.dfe.jwt-strategies#v4.1.0",
-    "request": "^2.88.2",
-    "request-promise": "^4.2.6",
+    "login.dfe.kue": "github:DFE-Digital/login.dfe.kue#v0.12.0",
     "uuid": "^8.3.2"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "login.dfe.public-api.jobs",
-  "version": "2.0.1",
+  "version": "2.1.1",
   "description": "Jobs required for DfE Sign-in public api",
   "main": "lib/index.js",
   "scripts": {


### PR DESCRIPTION
At the time of writing the `npm audit` command reports the following on the develop branch:

> 13 vulnerabilities (9 moderate, 4 high)

After this work the `npm audit` command now reports the following on this branch:

> found 0 vulnerabilities

### Overview of work undertaken

1. Automatically fix vulnerable dependencies with the `npm audit fix` command.
2. Update `login.dfe.*` dependencies from `git+https//` to `github:DFE-Digital`.
3. Remove `request-promise` and use `login.dfe.async-retry`
4. Upgrade `jsonwebtoken` from `8.5.1` to `9.0.2` to resolve known vulnerabilities.